### PR TITLE
Change input behaviour on enter

### DIFF
--- a/src/components/Input/input.tsx
+++ b/src/components/Input/input.tsx
@@ -47,6 +47,7 @@ export const SmartInput: React.FC<SmartInputProps> = (
         value: event.currentTarget.value
       });
       setInputValue("");
+      setEditing(false);
     }
   }
   function onChange(event: React.ChangeEvent<HTMLInputElement>): void {


### PR DESCRIPTION
Tiny tweak which just changes how the text input boxes behave after pressing return (editing is set to false so the new input value is rendered, not a blank value).