### PR TITLE
Tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6653,9 +6653,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -13740,6 +13740,11 @@
         "react-is": "^16.9.0",
         "scheduler": "^0.15.0"
       }
+    },
+    "react-tiny-popover": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-3.4.5.tgz",
+      "integrity": "sha512-vZHIMCsphBwgUcz6wnwq+BZnukNzZhSXYTpe5qqTYGr+mTyVKN6q8NXsNkokh5QGnTzO3FpB3P33J64F1oiTqg=="
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
+    "react-tiny-popover": "^3.4.5",
     "redux": "^4.0.4",
     "subscriptions-transport-ws": "^0.9.16",
     "typescript": "^3.6.3"

--- a/public/simple.json
+++ b/public/simple.json
@@ -1,0 +1,43 @@
+{
+  "type": "blank",
+  "x": "0",
+  "y": "0",
+  "width": "400px",
+  "height": "300px",
+  "children": [
+    {
+      "type": "label",
+      "x": "10px",
+      "y": "10px",
+      "width": "100px",
+      "height": "100px",
+      "text": "hello"
+    },
+    {
+      "type": "label",
+      "x": "210px",
+      "y": "10px",
+      "width": "100px",
+      "height": "100px",
+      "text": "hello"
+    },
+    {
+      "type": "input",
+      "pvName": "meta://metapv1",
+      "x": "10px",
+      "y": "120px",
+      "width": "100px",
+      "height": "100px",
+      "precision": 3
+    },
+    {
+      "type": "readback",
+      "pvName": "meta://metapv1",
+      "x": "210px",
+      "y": "120px",
+      "width": "100px",
+      "height": "100px",
+      "precision": 3
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ProgressPage } from "./pages/progressPage";
 import { PositioningExamplePage } from "./pages/positioningExamplePage";
 import { getStore, initialiseStore } from "./redux/store";
 import { SimulatorPlugin } from "./connection/sim";
+import { JsonPage } from "./pages/fromJson";
 
 const App: React.FC = (): JSX.Element => {
   const plugin = new SimulatorPlugin();
@@ -44,6 +45,9 @@ const App: React.FC = (): JSX.Element => {
             <Link style={styleLinkButton} to="/positioning">
               Positioning
             </Link>
+            <Link style={styleLinkButton} to="/fromJson">
+              JSON Loading
+            </Link>
           </div>
           <div
             id="Central Column"
@@ -63,6 +67,7 @@ const App: React.FC = (): JSX.Element => {
               exact
               component={PositioningExamplePage}
             />
+            <Route path="/fromJson" exact component={JsonPage} />
           </div>
         </div>
       </BrowserRouter>

--- a/src/components/AlarmBorder/alarmBorder.module.css
+++ b/src/components/AlarmBorder/alarmBorder.module.css
@@ -1,9 +1,9 @@
 .Children {
   position: absolute;
-  top: 5%;
-  left: 5%;
-  height: 90%;
-  width: 90%;
+  top: 0%;
+  left: 0%;
+  height: 100%;
+  width: 100%;
 }
 
 .Border {

--- a/src/components/AlarmBorder/alarmBorder.module.css
+++ b/src/components/AlarmBorder/alarmBorder.module.css
@@ -7,7 +7,8 @@
 }
 
 .Border {
-  border: solid 5px #000000;
+  border: solid 3px #000000;
+  box-sizing: border-box;
   position: absolute;
   top: 0px;
   left: 0px;
@@ -16,13 +17,13 @@
 }
 
 .MinorAlarm {
-  border: solid 5px #ffff18;
+  border: solid 3px #ffff18;
 }
 
 .MajorAlarm {
-  border: solid 5px #ff0000;
+  border: solid 3px #ff0000;
 }
 
 .NotConnected {
-  border: solid 5px #ffffff;
+  border: solid 3px #ffffff;
 }

--- a/src/components/AlarmBorder/alarmBorder.tsx
+++ b/src/components/AlarmBorder/alarmBorder.tsx
@@ -14,7 +14,7 @@ export const AlarmBorder = (props: {
     alarm = value.alarm;
   }
   // Sort out alarm border classes
-  let alarmClasses = [classes.Border];
+  let alarmClasses = [classes.Border, classes.Children];
   if (connected === false) {
     alarmClasses.push(classes.NotConnected);
   } else if (alarm.severity === 1) {
@@ -23,9 +23,5 @@ export const AlarmBorder = (props: {
     alarmClasses.push(classes.MajorAlarm);
   }
 
-  return (
-    <div className={alarmClasses.join(" ")}>
-      <div className={classes.Children}>{props.children}</div>
-    </div>
-  );
+  return <div className={alarmClasses.join(" ")}>{props.children}</div>;
 };

--- a/src/components/CopyWrapper/copyWrapper.module.css
+++ b/src/components/CopyWrapper/copyWrapper.module.css
@@ -11,7 +11,6 @@
 
 .CopyWrapper .tooltiptext {
   visibility: hidden;
-  width: 120px;
   background-color: black;
   color: #fff;
   text-align: center;

--- a/src/components/CopyWrapper/copyWrapper.module.css
+++ b/src/components/CopyWrapper/copyWrapper.module.css
@@ -1,48 +1,17 @@
-.CopyWrapper {
-  border: 1px solid #aaaaaa;
-  display: flex;
-  text-align: center;
-  position: relative;
-  /*top: 0px;
-  left: 0px;*/
-  height: 100%;
-  width: 100%;
-}
-
-.CopyWrapper .tooltiptext {
-  visibility: hidden;
+.ToolTip {
   background-color: black;
   white-space: pre-line;
   color: #fff;
   text-align: center;
   border-radius: 6px;
   padding: 5px 0;
-  position: absolute;
   z-index: 1;
   bottom: 110%;
   left: 50%;
-  margin-left: -60px;
-}
-
-.CopyWrapper .tooltiptext::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: black transparent transparent transparent;
-}
-
-.CopyWrapper:hover .tooltiptext {
-  visibility: visible;
 }
 
 .Children {
-  /*position: absolute;
-  top: 0px;
-  left: 0px;*/
+  cursor: context-menu;
   height: 100%;
   width: 100%;
 }

--- a/src/components/CopyWrapper/copyWrapper.module.css
+++ b/src/components/CopyWrapper/copyWrapper.module.css
@@ -12,6 +12,7 @@
 .CopyWrapper .tooltiptext {
   visibility: hidden;
   background-color: black;
+  white-space: pre-line;
   color: #fff;
   text-align: center;
   border-radius: 6px;

--- a/src/components/CopyWrapper/copyWrapper.test.tsx
+++ b/src/components/CopyWrapper/copyWrapper.test.tsx
@@ -2,8 +2,11 @@ import React from "react";
 import { shallow, ShallowWrapper } from "enzyme";
 
 import { CopyWrapper } from "./copyWrapper";
+import Popover from "react-tiny-popover";
 
 let wrapper: ShallowWrapper;
+let wrappedElement: ShallowWrapper;
+
 beforeEach((): void => {
   // Get current time, separate into seconds and nanoseconds
   let currentTime = new Date(0);
@@ -28,21 +31,23 @@ beforeEach((): void => {
     </CopyWrapper>
   );
   wrapper = shallow(copywrapper);
+  wrappedElement = wrapper.find(".Children").childAt(0);
 });
 
 describe("<CopyWrapper>", (): void => {
-  test("it renders a basic element", (): void => {
-    expect(wrapper.text()).toContain("Testing Copy Wrapper");
+  test("it contains a Popover", (): void => {
+    const popover = wrapper.find(Popover);
+    expect(popover.name()).toEqual("Popover");
+  });
+  test("it contains one child element", (): void => {
+    const children = wrapper.find(".Children");
+    expect(children).toHaveLength(1);
   });
 
-  test("it contains the date", (): void => {
-    expect(wrapper.text()).toContain(new Date(0));
+  test("it renders text", (): void => {
+    expect(wrappedElement.text()).toEqual("Testing Copy Wrapper");
   });
 
-  test("it contains the pv name", (): void => {
-    expect(wrapper.text()).toContain("pv");
-  });
-  test("it contains the value", (): void => {
-    expect(wrapper.text()).toContain("hello");
-  });
+  // How do we test the popover content? It renders on the
+  // <body> element not the Popover element.
 });

--- a/src/components/CopyWrapper/copyWrapper.tsx
+++ b/src/components/CopyWrapper/copyWrapper.tsx
@@ -47,6 +47,7 @@ export const CopyWrapper = (props: {
   ]
     .filter((word): boolean => word !== "")
     .join(", ");
+  toolTipText = `${pvName}\n[${toolTipText}]`;
 
   return (
     <div
@@ -55,10 +56,7 @@ export const CopyWrapper = (props: {
       onClick={copyPvToClipboard}
     >
       <div className={classes.Children}>{props.children}</div>
-      <span className={classes.tooltiptext}>
-        {pvName}
-        <br />[{toolTipText}]
-      </span>
+      <span className={classes.tooltiptext}>{toolTipText}</span>
     </div>
   );
 };

--- a/src/components/CopyWrapper/copyWrapper.tsx
+++ b/src/components/CopyWrapper/copyWrapper.tsx
@@ -62,7 +62,7 @@ export const CopyWrapper = (props: {
   toolTipText = `${pvName}\n[${toolTipText}]`;
 
   return (
-    <div style={{ height: "100%", width: "100%" }}>
+    <div style={{ position: "relative", height: "100%", width: "100%" }}>
       <Popover
         isOpen={popoverOpen}
         position={["top"]}

--- a/src/components/CopyWrapper/copyWrapper.tsx
+++ b/src/components/CopyWrapper/copyWrapper.tsx
@@ -3,8 +3,9 @@
 // These values will be displayed in a tooltip when highlighted
 // A middle mouse click will copy the PV name to the clipboard
 
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState } from "react";
 import copyToClipboard from "clipboard-copy";
+import Popover from "react-tiny-popover";
 
 import { connectionWrapper } from "../ConnectionWrapper/connectionWrapper";
 import { NType } from "../../ntypes";
@@ -17,7 +18,8 @@ export const CopyWrapper = (props: {
   children: ReactNode;
   style?: object;
 }): JSX.Element => {
-  let { connected, pvName, value = null, style = {} } = props;
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  let { connected, pvName, value = null } = props;
 
   let displayValue = "";
   if (!connected) {
@@ -30,11 +32,21 @@ export const CopyWrapper = (props: {
     }
   }
 
-  function copyPvToClipboard(e: React.MouseEvent): void {
+  const copyPvToClipboard = (e: React.MouseEvent): void => {
     if (e.button === 1) {
       copyToClipboard(pvName);
     }
-  }
+  };
+  const showPopover = (e: React.MouseEvent): void => {
+    if (e.button === 1) {
+      setPopoverOpen(true);
+    }
+  };
+  const hidePopover = (e: React.MouseEvent): void => {
+    if (e.button === 1) {
+      setPopoverOpen(false);
+    }
+  };
   // Compose the text which should be shown on the tooltip
   let toolTipText = [
     displayValue,
@@ -50,13 +62,24 @@ export const CopyWrapper = (props: {
   toolTipText = `${pvName}\n[${toolTipText}]`;
 
   return (
-    <div
-      className={classes.CopyWrapper}
-      style={style}
-      onClick={copyPvToClipboard}
-    >
-      <div className={classes.Children}>{props.children}</div>
-      <span className={classes.tooltiptext}>{toolTipText}</span>
+    <div style={{ height: "100%", width: "100%" }}>
+      <Popover
+        isOpen={popoverOpen}
+        position={["top"]}
+        onClickOutside={(): void => setPopoverOpen(false)}
+        content={(): JSX.Element => {
+          return <div className={classes.ToolTip}>{toolTipText}</div>;
+        }}
+      >
+        <div
+          onClick={copyPvToClipboard}
+          onMouseDown={showPopover}
+          onMouseUp={hidePopover}
+          className={classes.Children}
+        >
+          {props.children}
+        </div>
+      </Popover>
     </div>
   );
 };

--- a/src/components/FromJson/fromJson.tsx
+++ b/src/components/FromJson/fromJson.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import {
+  objectToPosition,
+  PositionDescription
+} from "../Positioning/positioning";
+import { Label } from "../Label/label";
+import { Blank } from "../Positioning/ionpExample";
+import { ConnectedStandaloneReadback } from "../Readback/readback";
+import { ConnectedInput } from "../Input/input";
+
+interface FromJsonProps {
+  file: string;
+}
+
+const EMPTY_DESC = {
+  type: "empty",
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0
+};
+
+export const FromJson = (props: FromJsonProps): JSX.Element => {
+  const [json, setJson] = useState<PositionDescription>(EMPTY_DESC);
+
+  if (json["type"] === "empty") {
+    fetch(props.file)
+      .then(
+        (response): Promise<any> => {
+          return response.json();
+        }
+      )
+      .then((json): void => {
+        setJson(json);
+      });
+  }
+  const compDict = {
+    blank: Blank,
+    empty: Blank,
+    label: Label,
+    readback: ConnectedStandaloneReadback,
+    input: ConnectedInput
+  };
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        height: json["height"]
+      }}
+    >
+      {objectToPosition(json, compDict)}
+    </div>
+  );
+};

--- a/src/components/Label/label.module.css
+++ b/src/components/Label/label.module.css
@@ -5,5 +5,4 @@
   width: 100%;
   color: black;
   background-color: #888888;
-  font-size: 0.7vw;
 }

--- a/src/components/Positioning/ionpExample.tsx
+++ b/src/components/Positioning/ionpExample.tsx
@@ -13,7 +13,8 @@ const Blank: React.FC = (props: any): JSX.Element => (
       height: "100%",
       width: "100%",
       border: "solid 5px black",
-      backgroundColor: "#dddddd"
+      backgroundColor: "#dddddd",
+      fontSize: "0.7vw"
     }}
   >
     {props.children}

--- a/src/components/Positioning/ionpExample.tsx
+++ b/src/components/Positioning/ionpExample.tsx
@@ -6,7 +6,7 @@ import { Readback } from "../Readback/readback";
 import { Input } from "../Input/input";
 import { ProgressBar } from "../ProgressBar/progressBar";
 
-const Blank: React.FC = (props: any): JSX.Element => (
+export const Blank: React.FC = (props: any): JSX.Element => (
   <div
     style={{
       position: "absolute",

--- a/src/pages/fromJson.tsx
+++ b/src/pages/fromJson.tsx
@@ -1,0 +1,22 @@
+// Simple page that loads from a JSON file directly.
+
+import React from "react";
+
+import { FromJson } from "../components/FromJson/fromJson";
+
+export const JsonPage = (): JSX.Element => (
+  <div
+    id="Central Column"
+    style={{
+      position: "relative",
+      height: "100%",
+      width: "80%",
+      margin: "auto"
+    }}
+  >
+    <h2>Loading from JSON</h2>
+    <div style={{ height: "100%", width: "100%" }}>
+      <FromJson file="http://localhost:3000/simple.json" />
+    </div>
+  </div>
+);


### PR DESCRIPTION
@skyfrench @TimGuiteDiamond a few changes, mostly fairly minor.

I moved to using `react-tiny-popover` for the tooltips, as it is a little simpler.