### PR TITLE
Use loglevel for logging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "graphql": "^14.5.5",
     "graphql-tag": "^2.10.1",
     "lint-staged": "^9.2.5",
+    "loglevel": "^1.6.4",
     "react": "^16.9.0",
     "react-apollo": "^3.1.0",
     "react-dom": "^16.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,11 @@ import { ReadbacksPage } from "./pages/readbacksPage";
 import { ProgressPage } from "./pages/progressPage";
 import { PositioningExamplePage } from "./pages/positioningExamplePage";
 import { getStore, initialiseStore } from "./redux/store";
+import log from "loglevel";
 import { SimulatorPlugin } from "./connection/sim";
 import { JsonPage } from "./pages/fromJson";
+
+log.setLevel("INFO");
 
 const App: React.FC = (): JSX.Element => {
   const plugin = new SimulatorPlugin();

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -5,6 +5,7 @@ import { WebSocketLink } from "apollo-link-ws";
 import { getMainDefinition } from "apollo-utilities";
 import gql from "graphql-tag";
 import { InMemoryCache, NormalizedCacheObject } from "apollo-cache-inmemory";
+import log from "loglevel";
 import { VType, vdoubleOf } from "../vtypes/vtypes";
 import {
   Connection,
@@ -78,11 +79,11 @@ export class ConiqlPlugin implements Connection {
       })
       .subscribe({
         next: (data): void => {
-          console.log("data", data); //eslint-disable-line no-console
+          log.debug("data", data);
           this.onValueUpdate(pvName1, data.data.subscribeFloatScalar);
         },
         error: (err): void => {
-          console.error("err", err); //eslint-disable-line no-console
+          log.error("err", err);
         }
       });
   }

--- a/src/connection/sim.ts
+++ b/src/connection/sim.ts
@@ -1,3 +1,4 @@
+import log from "loglevel";
 import {
   Connection,
   ConnectionState,
@@ -159,7 +160,7 @@ export class SimulatorPlugin implements Connection {
   }
 
   public subscribe(pvName: string): void {
-    console.log(`subscribing to ${pvName}`); //eslint-disable-line no-console
+    log.debug(`Subscribing to ${pvName}.`);
     if (pvName.startsWith("loc://")) {
       this.localPvs[pvName] = vdoubleOf(0);
       this.onConnectionUpdate(pvName, { isConnected: true });
@@ -215,6 +216,6 @@ export class SimulatorPlugin implements Connection {
   }
 
   public unsubscribe(pvName: string): void {
-    console.log(`unsubscribing from ${pvName}`); //eslint-disable-line no-console
+    log.debug(`Unsubscribing from ${pvName}.`);
   }
 }


### PR DESCRIPTION
This allows us to use (judicious) logging that can be turned off
when we don't need it. Closes #49.

@TimGuiteDiamond @skyfrench this is a simple change and I think it will be useful.