### PR TITLE
Remove getValue() from the Connection interface.

### DIFF
--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -6,7 +6,7 @@ import { getMainDefinition } from "apollo-utilities";
 import gql from "graphql-tag";
 import { InMemoryCache, NormalizedCacheObject } from "apollo-cache-inmemory";
 import log from "loglevel";
-import { VType, vdouble } from "../vtypes/vtypes";
+import { VType } from "../vtypes/vtypes";
 import {
   Connection,
   ConnectionChangedCallback,
@@ -90,10 +90,6 @@ export class ConiqlPlugin implements Connection {
 
   public putPv(pvName: string, value: VType): void {
     // noop
-  }
-
-  public getValue(pvName: string): VType {
-    return vdouble(0);
   }
 
   public unsubscribe(pvName: string): void {

--- a/src/connection/plugin.ts
+++ b/src/connection/plugin.ts
@@ -16,7 +16,6 @@ export type ValueChangedCallback = (pvName: string, value: VType) => void;
 export interface Connection {
   subscribe: (pvName: string) => void;
   putPv: (pvName: string, value: VType) => void;
-  getValue: (pvName: string) => VType;
   connect: (
     connectionCallback: ConnectionChangedCallback,
     valueCallback: ValueChangedCallback

--- a/src/connection/sim.ts
+++ b/src/connection/sim.ts
@@ -325,21 +325,6 @@ export class SimulatorPlugin implements Connection {
     }
   }
 
-  public getValue(pvName: string): VType {
-    if (pvName.startsWith("loc://")) {
-      return this.localPvs[pvName];
-    } else if (pvName.startsWith("sim://")) {
-      this.simPvs[pvName].getValue();
-    } else if (pvName === "sim://random") {
-      return vdouble(Math.random());
-    } else if (pvName.startsWith("meta://")) {
-      return this.localPvs[pvName];
-    } else if (pvName.startsWith("enum://")) {
-      return this.localPvs[pvName];
-    }
-    return vdouble(0);
-  }
-
   public unsubscribe(pvName: string): void {
     log.debug(`Unsubscribing from ${pvName}.`);
   }


### PR DESCRIPTION
As it is a synchronous call it doesn't really fit in the framework and I
don't actually think we need it.

I discussed this with Michael. We can always put things back in.

@TimGuiteDiamond @skyfrench @talwrii 