### PR TITLE
Connection forwarder -- Register pvname prefixes with different connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Settings
+src/settings.ts
+
+
 # dependencies
 /node_modules
 /.pnp

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ For more details on the development environment see
   developed by Facebook
 - [Prettier](https://github.com/prettier/prettier) is used for code formatting
 
+### Connection information
+
+This application can use data that come from external sources. These settings will vary from machine to machine, so must, if used, be configured when one checks out the source code.
+
+One needn't set connection information if you don't need any external sources of data; you could just use simulated and local process variables. However, if you want to connect to an external source of data:
+
+* Copying `src/settings.ts.template` to `src/settings.ts`
+* Editing `src/settings.ts` to contain the correct connection information
+
 ## Debugging
 
 The [loglevel](https://github.com/pimterry/loglevel) library is used for logging. To enable this, change the argument to `log.setLevel` in `App.tsx` and open the javascript console.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,16 @@ import { FlexExamplePage } from "./pages/flexExamplePage";
 import { EmbeddedPage } from "./pages/embeddedPage";
 
 import { SimulatorPlugin } from "./connection/sim";
-// import { ConiqlPlugin } from "./connection/coniql";
+import { ConiqlPlugin } from "./connection/coniql";
 import { ConnectionForwarder } from "./connection/forwarder";
+
+var settings: any;
+try {
+  // Use require so that we can catch this error
+  settings = require("./settings");
+} catch (e) {
+  settings = {};
+}
 
 log.setLevel("warn");
 
@@ -34,8 +42,12 @@ function applyTheme(theme: any): void {
 
 const App: React.FC = (): JSX.Element => {
   const simulator = new SimulatorPlugin();
-  //"const coniql = new ConiqlPlugin();
-  const coniql = undefined;
+  var coniql;
+  if (settings.coniqlSocket !== undefined) {
+    coniql = new ConiqlPlugin(settings.coniqlSocket);
+  } else {
+    coniql = undefined;
+  }
   const fallbackPlugin = simulator;
   const plugin = new ConnectionForwarder([
     ["sim://", simulator],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,10 @@ import { MacrosPage } from "./pages/macrosPage";
 import { lightTheme, darkTheme, ThemeContext } from "./themeContext";
 import { FlexExamplePage } from "./pages/flexExamplePage";
 import { EmbeddedPage } from "./pages/embeddedPage";
+
 import { SimulatorPlugin } from "./connection/sim";
+// import { ConiqlPlugin } from "./connection/coniql";
+import { ConnectionForwarder } from "./connection/forwarder";
 
 log.setLevel("warn");
 
@@ -30,7 +33,16 @@ function applyTheme(theme: any): void {
 }
 
 const App: React.FC = (): JSX.Element => {
-  const plugin = new SimulatorPlugin();
+  const simulator = new SimulatorPlugin();
+  //"const coniql = new ConiqlPlugin();
+  const coniql = undefined;
+  const fallbackPlugin = simulator;
+  const plugin = new ConnectionForwarder([
+    ["sim://", simulator],
+    ["loc://", simulator],
+    ["pva://", coniql],
+    ["", fallbackPlugin]
+  ]);
   initialiseStore(plugin);
   const store = getStore();
   const { toggle, dark } = React.useContext(ThemeContext);

--- a/src/connection/forwarder.ts
+++ b/src/connection/forwarder.ts
@@ -1,0 +1,58 @@
+import {
+  Connection,
+  ConnectionChangedCallback,
+  ValueChangedCallback
+} from "./plugin";
+
+export class ConnectionForwarder implements Connection {
+  private prefixConnections: [string, Connection | undefined][];
+  private connected: boolean;
+  public constructor(prefixConnections: [string, Connection | undefined][]) {
+    this.prefixConnections = prefixConnections;
+    this.connected = false;
+  }
+  private getConnection(pvName: string): Connection {
+    for (let [prefix, connection] of this.prefixConnections) {
+      if (pvName.startsWith(prefix)) {
+        if (connection !== undefined) {
+          return connection;
+        } else {
+          throw new Error(`Connection for {prefix} not initiated`);
+        }
+      }
+    }
+    throw new Error(`No connections for ${pvName}`);
+  }
+
+  public subscribe(pvName: string): string {
+    let connection = this.getConnection(pvName);
+    return connection.subscribe(pvName);
+  }
+
+  public unsubscribe(pvName: string): void {
+    let connection = this.getConnection(pvName);
+    return connection.unsubscribe(pvName);
+  }
+
+  public isConnected(): boolean {
+    return this.connected;
+  }
+
+  public putPv(pvName: string, value: any): void {
+    let connection = this.getConnection(pvName);
+    return connection.putPv(pvName, value);
+  }
+
+  public connect(
+    connectionCallback: ConnectionChangedCallback,
+    valueCallback: ValueChangedCallback
+  ): void {
+    for (var [, connection] of this.prefixConnections) {
+      if (connection !== undefined) {
+        if (!connection.isConnected()) {
+          connection.connect(connectionCallback, valueCallback);
+        }
+      }
+    }
+  }
+}

--- a/src/settings.ts.template
+++ b/src/settings.ts.template
@@ -1,0 +1,1 @@
+export const coniqlSocket = "localhost:1000";


### PR DESCRIPTION
I maintain a global list of prefix in `App.tsx`.

Given that we have a limited number of connections of prefixes and all plugins are written as part of the main source tree rather than by third parties, I think this approach is easier to understand: 

* We can see all the prefixes in one go
* Avoid collisions
* It's immediately transparent from reading the code what change has to be made to register a new prefix. 

Further, without doing some metaprogramming, we could still need to do a registration step to get the prefixes onto the connection forwarder (`forwarder.register(Coniql)`) - a step that is easily forgotten if we have plugins list their prefixes.
 