### PR TITLE
* Log at info level in tests

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,7 @@
 import { configure } from "enzyme";
+import log from "loglevel";
 import Adapter from "enzyme-adapter-react-16";
 // tslint:disable-next-line:no-any
 configure({ adapter: new Adapter() });
+
+log.setLevel("INFO");


### PR DESCRIPTION
Debug renders test output unreadable. I feel that INFO is a good trade
off between finding out what is running when an error occurs and not
producing unreadable output.