### PR TITLE
Restored styling capabilities

### DIFF
--- a/public/embeddedScreens/simpleEmbed.json
+++ b/public/embeddedScreens/simpleEmbed.json
@@ -11,21 +11,24 @@
     {
       "type": "label",
       "containerStyling": {
-        "position": "relative"
+        "position": "relative",
+        "height": "100%"
       },
       "text": "Screen: ${EMBEDSUFFIX}"
     },
     {
       "type": "input",
       "containerStyling": {
-        "position": "relative"
+        "position": "relative",
+        "height": "100%"
       },
       "pvName": "sim://limit#pv${EMBEDSUFFIX}"
     },
     {
       "type": "readback",
       "containerStyling": {
-        "position": "relative"
+        "position": "relative",
+        "height": "100%"
       },
       "pvName": "sim://limit#pv${EMBEDSUFFIX}",
       "precision": 3

--- a/src/components/Display/display.tsx
+++ b/src/components/Display/display.tsx
@@ -17,7 +17,13 @@ const DisplayComponent = (
   props: InferWidgetProps<typeof DisplayProps> & Component
 ): JSX.Element => (
   <div
-    style={{ position: "relative", boxSizing: "border-box", ...props.style }}
+    style={{
+      position: "relative",
+      boxSizing: "border-box",
+      height: "100%",
+      width: "100%",
+      ...props.style
+    }}
   >
     {props.children}
   </div>

--- a/src/components/FlexContainer/flexContainer.module.css
+++ b/src/components/FlexContainer/flexContainer.module.css
@@ -3,6 +3,8 @@
 
   flex-flow: row wrap;
   justify-content: space-around;
+  height: 100%;
+  width: 100%;
 }
 
 .column {

--- a/src/components/TooltipWrapper/tooltipWrapper.module.css
+++ b/src/components/TooltipWrapper/tooltipWrapper.module.css
@@ -17,8 +17,3 @@
 .Copying {
   cursor: crosshair;
 }
-
-.Children {
-  height: 100%;
-  width: 100%;
-}

--- a/src/components/TooltipWrapper/tooltipWrapper.test.tsx
+++ b/src/components/TooltipWrapper/tooltipWrapper.test.tsx
@@ -21,7 +21,7 @@ beforeEach((): void => {
     </TooltipWrapper>
   );
   wrapper = shallow(tooltipWrapper);
-  wrappedElement = wrapper.find(".Children").childAt(0);
+  wrappedElement = wrapper.childAt(0);
 });
 
 describe("TooltipWrapper", (): void => {
@@ -30,12 +30,12 @@ describe("TooltipWrapper", (): void => {
     expect(popover.name()).toEqual("Popover");
   });
   test("it contains one child element", (): void => {
-    const children = wrapper.find(".Children");
+    const children = wrapper.children();
     expect(children).toHaveLength(1);
   });
 
   test("it renders text", (): void => {
-    expect(wrappedElement.text()).toEqual("Testing Tooltip Wrapper");
+    expect(wrappedElement.childAt(0).text()).toEqual("Testing Tooltip Wrapper");
   });
 
   // How do we test the popover content? It renders on the

--- a/src/components/TooltipWrapper/tooltipWrapper.tsx
+++ b/src/components/TooltipWrapper/tooltipWrapper.tsx
@@ -22,7 +22,7 @@ export const TooltipWrapper = (props: {
   const [popoverOpen, setPopoverOpen] = useState(false);
   let { pvName, style = {} } = props;
 
-  let activeClasses = classes.Children;
+  let activeClasses = "";
   if (props.resolvedTooltip) {
     activeClasses += ` ${classes.TooltipAvailable}`;
   }
@@ -45,14 +45,7 @@ export const TooltipWrapper = (props: {
 
   if (props.resolvedTooltip) {
     return (
-      <div
-        style={{
-          position: "relative",
-          height: "100%",
-          width: "100%",
-          ...style
-        }}
-      >
+      <div style={{ height: "100%", width: "100%", ...style }}>
         <Popover
           isOpen={popoverOpen}
           position={["top"]}
@@ -67,6 +60,7 @@ export const TooltipWrapper = (props: {
             onMouseDown={mouseDown}
             onMouseUp={mouseUp}
             className={activeClasses}
+            style={{ height: "100%", width: "100%" }}
           >
             {props.children}
           </div>
@@ -79,6 +73,7 @@ export const TooltipWrapper = (props: {
         onMouseDown={mouseDown}
         onMouseUp={mouseUp}
         className={activeClasses}
+        style={style}
       >
         {props.children}
       </div>

--- a/src/components/Widget/widget.tsx
+++ b/src/components/Widget/widget.tsx
@@ -179,7 +179,7 @@ export const Widget = (props: WidgetComponent): JSX.Element => {
   let { baseWidget, widgetStyling = {}, ...baseWidgetProps } = containerProps;
 
   // Put appropriate components on the list of components to be wrapped
-  let components = [baseWidget];
+  let components = [TooltipWrapper, baseWidget];
 
   return recursiveWrapping(
     components,

--- a/src/components/Widget/widget.tsx
+++ b/src/components/Widget/widget.tsx
@@ -179,7 +179,7 @@ export const Widget = (props: WidgetComponent): JSX.Element => {
   let { baseWidget, widgetStyling = {}, ...baseWidgetProps } = containerProps;
 
   // Put appropriate components on the list of components to be wrapped
-  let components = [TooltipWrapper, baseWidget];
+  let components = [baseWidget];
 
   return recursiveWrapping(
     components,


### PR DESCRIPTION
I have changed the code such that it behaves in the way I think it did before. In some places this has required defaulting heights and widths to 100%. This is acceptable because some components do not know whether they will be wrapped in another component which will give them size or not.

However, I have removed Tooltip from **Widget**, this should be added back in but only when tooltip is required on a **Widget**.