### PR TITLE
Wrapper styling fixes

### DIFF
--- a/src/components/AlarmBorder/alarmBorder.module.css
+++ b/src/components/AlarmBorder/alarmBorder.module.css
@@ -2,8 +2,6 @@
   position: absolute;
   top: 0%;
   left: 0%;
-  height: 100%;
-  width: 100%;
 }
 
 .Border {
@@ -12,8 +10,6 @@
   position: relative;
   top: 0px;
   left: 0px;
-  height: 100%;
-  width: 100%;
 }
 
 .MinorAlarm {

--- a/src/components/Display/display.tsx
+++ b/src/components/Display/display.tsx
@@ -20,8 +20,6 @@ const DisplayComponent = (
     style={{
       position: "relative",
       boxSizing: "border-box",
-      height: "100%",
-      width: "100%",
       ...props.style
     }}
   >

--- a/src/components/MenuWrapper/menuWrapper.tsx
+++ b/src/components/MenuWrapper/menuWrapper.tsx
@@ -67,7 +67,7 @@ export const MenuWrapper = (props: {
   if (contextOpen) {
     return (
       <div
-        style={{ height: "100%", width: "100%", ...props.style }}
+        style={props.style}
         onContextMenu={handleClick}
         onMouseLeave={handleMouseLeave}
       >
@@ -78,7 +78,7 @@ export const MenuWrapper = (props: {
   } else
     return (
       <div
-        style={{ height: "100%", width: "100%", ...props.style }}
+        style={props.style}
         onContextMenu={handleClick}
         onMouseLeave={handleMouseLeave}
       >

--- a/src/components/MenuWrapper/menuWrapper.tsx
+++ b/src/components/MenuWrapper/menuWrapper.tsx
@@ -67,7 +67,7 @@ export const MenuWrapper = (props: {
   if (contextOpen) {
     return (
       <div
-        style={props.style}
+        style={{ height: "100%", width: "100%", ...props.style }}
         onContextMenu={handleClick}
         onMouseLeave={handleMouseLeave}
       >
@@ -78,7 +78,7 @@ export const MenuWrapper = (props: {
   } else
     return (
       <div
-        style={props.style}
+        style={{ height: "100%", width: "100%", ...props.style }}
         onContextMenu={handleClick}
         onMouseLeave={handleMouseLeave}
       >

--- a/src/components/TooltipWrapper/tooltipWrapper.tsx
+++ b/src/components/TooltipWrapper/tooltipWrapper.tsx
@@ -73,7 +73,7 @@ export const TooltipWrapper = (props: {
         onMouseDown={mouseDown}
         onMouseUp={mouseUp}
         className={activeClasses}
-        style={style}
+        style={{ height: "100%", width: "100%", ...style }}
       >
         {props.children}
       </div>

--- a/src/components/TooltipWrapper/tooltipWrapper.tsx
+++ b/src/components/TooltipWrapper/tooltipWrapper.tsx
@@ -45,7 +45,7 @@ export const TooltipWrapper = (props: {
 
   if (props.resolvedTooltip) {
     return (
-      <div style={{ height: "100%", width: "100%", ...style }}>
+      <div style={style}>
         <Popover
           isOpen={popoverOpen}
           position={["top"]}
@@ -73,7 +73,7 @@ export const TooltipWrapper = (props: {
         onMouseDown={mouseDown}
         onMouseUp={mouseUp}
         className={activeClasses}
-        style={{ height: "100%", width: "100%", ...style }}
+        style={style}
       >
         {props.children}
       </div>

--- a/src/components/Widget/widget.tsx
+++ b/src/components/Widget/widget.tsx
@@ -167,7 +167,7 @@ const recursiveWrapping = (
       <Component style={containerStyling} {...containerProps}>
         {recursiveWrapping(
           remainingComponents,
-          {},
+          { height: "100%", width: "100%" },
           widgetStyling,
           containerProps,
           widgetProps


### PR DESCRIPTION
Put the styling fix in the recursive wrapping function now so any nested elements will pop to the size of the parent, but if they are the top level then the correct size will be applied