### PR TITLE
Optional pvname

### DIFF
--- a/src/components/Widget/widget.tsx
+++ b/src/components/Widget/widget.tsx
@@ -131,7 +131,7 @@ type WidgetComponent = WidgetProps & { baseWidget: React.FC<any> };
 
 // Internal prop types object for properties which are not in a standard widget
 const PVExtras = {
-  pvName: PropTypes.string.isRequired,
+  pvName: PropTypes.string,
   alarmBorder: PropTypes.bool
 };
 // PropTypes object for a PV widget which can be expanded

--- a/src/hooks/useConnection.test.ts
+++ b/src/hooks/useConnection.test.ts
@@ -1,0 +1,42 @@
+import { useSelector } from "react-redux";
+import { vdouble } from "../vtypes/vtypes";
+import { useConnection } from "./useConnection";
+
+const TEST_VAL = vdouble(2);
+
+// Mock useSubscription.
+jest.mock("./useSubscription", (): object => {
+  return {
+    useSubscription: jest.fn()
+  };
+});
+// Mock useSelector.
+jest.mock("react-redux", (): object => {
+  return {
+    useSelector: jest.fn()
+  };
+});
+// This has to be done in a second step because Jest does the
+// mocking before we have access to other imports (vdouble).
+(useSelector as jest.Mock).mockImplementation((pvName: string): any => {
+  return {
+    PV1: [{ value: TEST_VAL, connected: true, readonly: false }, "PV1"]
+  };
+});
+
+describe("useConnection", (): void => {
+  it("returns null values if pvName undefined", (): void => {
+    const [epn, connected, readonly, value] = useConnection("id1", undefined);
+    expect(epn).toEqual("undefined");
+    expect(connected).toEqual(false);
+    expect(readonly).toEqual(false);
+    expect(value).toEqual(undefined);
+  });
+  it("returns valid values if pvName returns data", (): void => {
+    const [epn, connected, readonly, value] = useConnection("id1", "PV1");
+    expect(epn).toEqual("PV1");
+    expect(connected).toEqual(true);
+    expect(readonly).toEqual(false);
+    expect(value).toEqual(TEST_VAL);
+  });
+});

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -12,19 +12,28 @@ export interface PvProps extends React.PropsWithChildren<any> {
 
 export function useConnection(
   id: string,
-  pvName: string
+  pvName?: string
 ): [string, boolean, boolean, VType?] {
-  useSubscription(id, [pvName]);
+  const pvNameArray = pvName === undefined ? [] : [pvName];
+  useSubscription(id, pvNameArray);
   const pvResults = useSelector(
-    (state: CsState): PvArrayResults => pvStateSelector([pvName], state),
+    (state: CsState): PvArrayResults => pvStateSelector(pvNameArray, state),
     pvStateComparator
   );
-  const [pvState, effectivePvName] = pvResults[pvName];
-  if (pvState) {
-    const connected = pvState.connected || false;
-    const readonly = pvState.readonly || false;
-    return [effectivePvName, connected, readonly, pvState.value];
+  let connected = false;
+  let readonly = false;
+  let effectivePvName = pvName === undefined ? "undefined" : pvName;
+  let value = undefined;
+  if (pvName !== undefined) {
+    const [pvState, effPvName] = pvResults[pvName];
+    effectivePvName = effPvName;
+    if (pvState) {
+      connected = pvState.connected || false;
+      readonly = pvState.readonly || false;
+      value = pvState.value;
+    } else {
+    }
   } else {
-    return [effectivePvName, false, false, undefined];
   }
+  return [effectivePvName, connected, readonly, value];
 }

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -22,8 +22,8 @@ export function useConnection(
   );
   let connected = false;
   let readonly = false;
-  let effectivePvName = pvName === undefined ? "undefined" : pvName;
   let value = undefined;
+  let effectivePvName = "undefined";
   if (pvName !== undefined) {
     const [pvState, effPvName] = pvResults[pvName];
     effectivePvName = effPvName;
@@ -31,9 +31,7 @@ export function useConnection(
       connected = pvState.connected || false;
       readonly = pvState.readonly || false;
       value = pvState.value;
-    } else {
     }
-  } else {
   }
   return [effectivePvName, connected, readonly, value];
 }


### PR DESCRIPTION
@TimGuiteDiamond make PV name optional on PV widgets.

It's often the case that you don't want a PV.