### PR TITLE
Extract execute as one property from bob files

### DIFF
--- a/src/components/FromBob/bobConversionUtils.test.ts
+++ b/src/components/FromBob/bobConversionUtils.test.ts
@@ -90,6 +90,41 @@ describe("actions conversion", (): void => {
       ]
     });
   });
+  test("it correctly converts actions which execute as one", (): void => {
+    const xmlActions = `
+    <actions execute_as_one="true">
+      <action type="write_pv">
+        <pv_name>testPV1</pv_name>
+        <value>1</value>
+        <description>Write pv1 to 1</description>
+      </action>
+      <action type="write_pv">
+        <pv_name>testPV2</pv_name>
+        <value>Testing</value>
+        <description>Write pv2 to Testing</description>
+      </action>
+    </actions>`;
+    const compactActions: convert.ElementCompact = convert.xml2js(xmlActions, {
+      compact: true
+    });
+    expect(bobParseActions("actions", compactActions.actions)).toEqual({
+      executeAsOne: true,
+      actions: [
+        {
+          type: WRITE_PV,
+          pvName: "testPV1",
+          value: "1",
+          description: "Write pv1 to 1"
+        },
+        {
+          type: WRITE_PV,
+          pvName: "testPV2",
+          value: "Testing",
+          description: "Write pv2 to Testing"
+        }
+      ]
+    });
+  });
 });
 
 describe("bob child conversion", (): void => {

--- a/src/components/FromBob/bobConversionUtils.ts
+++ b/src/components/FromBob/bobConversionUtils.ts
@@ -98,8 +98,18 @@ export const bobParseActions = (
     WRITE_PV: WRITE_PV
   };
 
+  // Extract information about whether to execute all actions at once
+  const executeAsOne =
+    (jsonProp._attributes !== undefined &&
+      jsonProp._attributes.execute_as_one) === "true"
+      ? true
+      : false;
+
   // Turn into an array of Actions
-  let processedActions: WidgetActions = { executeAsOne: false, actions: [] };
+  let processedActions: WidgetActions = {
+    executeAsOne: executeAsOne,
+    actions: []
+  };
 
   actionsToProcess.forEach((action): void => {
     log.debug(action);


### PR DESCRIPTION
Fix for bob files only. Opi files have `hook` attribute for executing first action in list on mouse click and `hook_all` for executing all on mouse click. Not going to handle that now.