### PR TITLE
Remove the widgetStyling prop.

### DIFF
--- a/src/ui/widgets/ActionButton/__snapshots__/actionButton.test.tsx.snap
+++ b/src/ui/widgets/ActionButton/__snapshots__/actionButton.test.tsx.snap
@@ -4,6 +4,14 @@ exports[`<ActionButton /> it matches the snapshot 1`] = `
 <button
   className="actionbutton"
   onClick={[Function]}
+  style={
+    Object {
+      "backgroundColor": undefined,
+      "height": "100%",
+      "textAlign": "center",
+      "width": "100%",
+    }
+  }
 >
   hello
 </button>

--- a/src/ui/widgets/ActionButton/__snapshots__/actionButton.test.tsx.snap
+++ b/src/ui/widgets/ActionButton/__snapshots__/actionButton.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<ActionButton /> it matches the snapshot 1`] = `
   style={
     Object {
       "backgroundColor": undefined,
+      "color": undefined,
       "height": "100%",
       "textAlign": "center",
       "width": "100%",

--- a/src/ui/widgets/ActionButton/actionButton.tsx
+++ b/src/ui/widgets/ActionButton/actionButton.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { WidgetActions, executeActions } from "../widgetActions";
-import { PVComponent, PVWidget, PVWidgetPropType } from "../widget";
+import { PVWidget, PVWidgetPropType } from "../widget";
 import classes from "./actionButton.module.css";
 import { useHistory } from "react-router-dom";
 import { registerWidget } from "../register";
@@ -16,8 +16,9 @@ import { BaseUrlContext } from "../../../baseUrl";
 export interface ActionButtonProps {
   text: string;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  style?: {};
   image?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
 }
 
 export const ActionButtonComponent = (
@@ -32,7 +33,12 @@ export const ActionButtonComponent = (
     <button
       className={classes.actionbutton}
       onClick={props.onClick}
-      style={props.style}
+      style={{
+        height: "100%",
+        width: "100%",
+        textAlign: "center",
+        backgroundColor: props.backgroundColor
+      }}
     >
       {src !== undefined ? (
         <figure className={classes.figure}>
@@ -49,8 +55,10 @@ export const ActionButtonComponent = (
 const ActionButtonPropType = {
   text: StringProp,
   actions: ActionsPropType,
-  style: ObjectPropOpt,
-  image: StringPropOpt
+  positionStyle: ObjectPropOpt,
+  image: StringPropOpt,
+  backgroundColor: StringPropOpt,
+  foregroundColor: StringPropOpt
 };
 
 const ActionButtonProps = {
@@ -60,7 +68,7 @@ const ActionButtonProps = {
 
 // Menu button which also knows how to write to a PV
 export const ActionButtonWidget = (
-  props: InferWidgetProps<typeof ActionButtonPropType> & PVComponent
+  props: InferWidgetProps<typeof ActionButtonPropType>
 ): JSX.Element => {
   // Function to send the value on to the PV
   const history = useHistory();
@@ -71,9 +79,10 @@ export const ActionButtonWidget = (
   return (
     <ActionButtonComponent
       text={props.text}
-      style={props.style}
       onClick={onClick}
       image={props.image}
+      backgroundColor={props.backgroundColor}
+      foregroundColor={props.foregroundColor}
     />
   );
 };

--- a/src/ui/widgets/ActionButton/actionButton.tsx
+++ b/src/ui/widgets/ActionButton/actionButton.tsx
@@ -37,7 +37,8 @@ export const ActionButtonComponent = (
         height: "100%",
         width: "100%",
         textAlign: "center",
-        backgroundColor: props.backgroundColor
+        backgroundColor: props.backgroundColor,
+        color: props.foregroundColor
       }}
     >
       {src !== undefined ? (

--- a/src/ui/widgets/Display/display.tsx
+++ b/src/ui/widgets/Display/display.tsx
@@ -1,24 +1,30 @@
 import React from "react";
 
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { registerWidget } from "../register";
-import { ChoicePropOpt, ChildrenPropOpt, InferWidgetProps } from "../propTypes";
+import {
+  ChoicePropOpt,
+  ChildrenPropOpt,
+  InferWidgetProps,
+  StringPropOpt
+} from "../propTypes";
 
 const DisplayProps = {
   children: ChildrenPropOpt,
-  overflow: ChoicePropOpt(["scroll", "hidden", "auto", "visible"])
+  overflow: ChoicePropOpt(["scroll", "hidden", "auto", "visible"]),
+  backgroundColor: StringPropOpt
 };
 
 // Generic display widget to put other things inside
 const DisplayComponent = (
-  props: InferWidgetProps<typeof DisplayProps> & Component
+  props: InferWidgetProps<typeof DisplayProps>
 ): JSX.Element => (
   <div
     style={{
       position: "relative",
       boxSizing: "border-box",
       overflow: props.overflow,
-      ...props.style
+      backgroundColor: props.backgroundColor
     }}
   >
     {props.children}

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import log from "loglevel";
 import { Route, RouteComponentProps } from "react-router-dom";
 
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { ActionButton } from "../ActionButton/actionButton";
 import { CLOSE_PAGE } from "../widgetActions";
 import { registerWidget } from "../register";
@@ -52,9 +52,9 @@ const DynamicPageProps = {
 
 // Generic display widget to put other things inside
 const DynamicPageComponent = (
-  props: InferWidgetProps<typeof DynamicPageProps> & Component
+  props: InferWidgetProps<typeof DynamicPageProps>
 ): JSX.Element => (
-  <div style={props.style}>
+  <div>
     <Route
       path={`*/${props.routePath}/:json/:macros`}
       render={(routeProps): JSX.Element => (
@@ -86,12 +86,8 @@ const DynamicPageComponent = (
                   minWidth: "",
                   maxWidth: ""
                 }}
-                widgetStyling={{
-                  textAlign: "center",
-                  fontWeight: "bold",
-                  backgroundColor: "#ff3333",
-                  color: "#ffffff"
-                }}
+                backgroundColor="#ff3333"
+                foregroundColor="#ffffff"
                 actions={{
                   executeAsOne: false,
                   actions: [

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.ts
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.ts
@@ -126,7 +126,6 @@ export const EmbeddedDisplay = (
       {
         type: "display",
         containerStyling: props.containerStyling,
-        widgetStyling: props.widgetStyling,
         overflow: overflow,
         children: [description]
       },

--- a/src/ui/widgets/FlexContainer/flexContainer.tsx
+++ b/src/ui/widgets/FlexContainer/flexContainer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import classes from "./flexContainer.module.css";
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { registerWidget } from "../register";
 import { ChildrenPropOpt, ChoicePropOpt, InferWidgetProps } from "../propTypes";
 
@@ -11,18 +11,14 @@ const FlexProps = {
 };
 
 export const FlexContainerComponent = (
-  props: InferWidgetProps<typeof FlexProps> & Component
+  props: InferWidgetProps<typeof FlexProps>
 ): JSX.Element => {
   const classNames = [classes.FlexContainer];
   const { flexFlow = null } = props;
   if (flexFlow !== null) {
     classNames.push(classes[flexFlow]);
   }
-  return (
-    <div className={classNames.join(" ")} style={props.style}>
-      {props.children}
-    </div>
-  );
+  return <div className={classNames.join(" ")}>{props.children}</div>;
 };
 
 const FlexWidgetProps = {

--- a/src/ui/widgets/GroupingContainer/groupingContainer.tsx
+++ b/src/ui/widgets/GroupingContainer/groupingContainer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { registerWidget } from "../register";
 import { StringProp, ChildrenPropOpt, InferWidgetProps } from "../propTypes";
 
@@ -11,15 +11,14 @@ const GroupingContainerProps = {
 
 // Generic display widget to put other things inside
 export const GroupingContainerComponent = (
-  props: InferWidgetProps<typeof GroupingContainerProps> & Component
+  props: InferWidgetProps<typeof GroupingContainerProps>
 ): JSX.Element => (
   // Uses an inner margin for children similar to Phoebus
   // This prevents the title being overwritten
   // Could be changed or perhaps customisable as a prop
   <fieldset
     style={{
-      boxSizing: "border-box",
-      ...props.style
+      boxSizing: "border-box"
     }}
   >
     <legend>{props.name}</legend>

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, useContext } from "react";
 
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import {
   InferWidgetProps,
   StringProp,
@@ -17,7 +17,7 @@ const ImageProps = {
 };
 
 export const ImageComponent = (
-  props: InferWidgetProps<typeof ImageProps> & Component
+  props: InferWidgetProps<typeof ImageProps>
 ): JSX.Element => {
   const baseUrl = useContext(BaseUrlContext);
   let file = `img/${props.src}`;
@@ -33,8 +33,7 @@ export const ImageComponent = (
 
   const style: CSSProperties = {
     overflow: overflow,
-    textAlign: "left",
-    ...props.style
+    textAlign: "left"
   };
 
   return (

--- a/src/ui/widgets/Input/input.tsx
+++ b/src/ui/widgets/Input/input.tsx
@@ -80,7 +80,6 @@ export const SmartInputComponent = (props: PVInputComponent): JSX.Element => {
       onChange={onChange}
       onBlur={onBlur}
       onClick={onClick}
-      style={props.style}
     />
   );
 };

--- a/src/ui/widgets/Label/label.tsx
+++ b/src/ui/widgets/Label/label.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import classes from "./label.module.css";
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { registerWidget } from "../register";
 import { BoolPropOpt, StringOrNumProp, InferWidgetProps } from "../propTypes";
 
@@ -12,9 +12,9 @@ const LabelProps = {
 };
 
 export const LabelComponent = (
-  props: InferWidgetProps<typeof LabelProps> & Component
+  props: InferWidgetProps<typeof LabelProps>
 ): JSX.Element => {
-  const style: any = { ...props.style };
+  const style: any = {};
   if (props.visible !== undefined && !props.visible) {
     style["visibility"] = "hidden";
   }

--- a/src/ui/widgets/ProgressBar/progressBar.tsx
+++ b/src/ui/widgets/ProgressBar/progressBar.tsx
@@ -52,8 +52,7 @@ export const ProgressBarComponent = (
     onStyle = {
       ...barColor,
       width: "100%",
-      height: `${onPercent}%`,
-      ...props.style
+      height: `${onPercent}%`
     };
   } else {
     onStyle = {
@@ -72,7 +71,7 @@ export const ProgressBarComponent = (
       : numValue.toString();
 
   return (
-    <div className={classes.bar} style={{ ...props.style }}>
+    <div className={classes.bar}>
       <div className={classes.off} style={offStyle} />
       <div className={classes.on} style={onStyle} />
       <div className={classes.label}>{valueText.toString()}</div>

--- a/src/ui/widgets/Readback/__snapshots__/readback.test.tsx.snap
+++ b/src/ui/widgets/Readback/__snapshots__/readback.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`<Readback /> it matches the snapshot 1`] = `
   style={
     Object {
       "backgroundColor": "#383838",
+      "height": "100%",
+      "width": "100%",
     }
   }
 >

--- a/src/ui/widgets/Readback/readback.tsx
+++ b/src/ui/widgets/Readback/readback.tsx
@@ -34,7 +34,6 @@ export const ReadbackComponent = (
   props: ReadbackComponentProps
 ): JSX.Element => {
   const { connected, value, precision, showUnits = false } = props;
-  let { style } = props;
   const alarm = alarmOf(value);
   const display = displayOf(value);
   let displayedValue;
@@ -43,7 +42,11 @@ export const ReadbackComponent = (
   } else {
     displayedValue = vtypeToString(value, precision);
   }
-  style = { backgroundColor: "#383838", ...props.style };
+  let style: any = {
+    backgroundColor: "#383838",
+    height: "100%",
+    width: "100%"
+  };
 
   // Add units if there are any and show units is true
   if (showUnits === true && display.getUnit() !== "") {

--- a/src/ui/widgets/Shape/shape.tsx
+++ b/src/ui/widgets/Shape/shape.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Component, Widget, WidgetPropType } from "../widget";
+import { Widget, WidgetPropType } from "../widget";
 import { registerWidget } from "../register";
 import { BoolPropOpt, StringPropOpt, InferWidgetProps } from "../propTypes";
 
@@ -12,10 +12,9 @@ const ShapeProps = {
 };
 
 export const ShapeComponent = (
-  props: InferWidgetProps<typeof ShapeProps> & Component
+  props: InferWidgetProps<typeof ShapeProps>
 ): JSX.Element => {
   const newStyle: any = {
-    ...props.style,
     width: props.shapeWidth ? props.shapeWidth : "100%",
     height: props.shapeHeight ? props.shapeHeight : "100%",
     borderRadius: props.shapeRadius ? props.shapeRadius : "",

--- a/src/ui/widgets/SlideControl/slideControl.tsx
+++ b/src/ui/widgets/SlideControl/slideControl.tsx
@@ -26,7 +26,6 @@ export const SlideControlComponent = (
     max = 100,
     /* TODO: Implement vertical style and allow absolute positioning */
     //vertical = false,
-    style = {},
     precision = undefined
   } = props;
 
@@ -51,7 +50,7 @@ export const SlideControlComponent = (
   }
 
   return (
-    <div style={style}>
+    <div>
       <div
         style={{
           display: "block",
@@ -90,7 +89,6 @@ export const SlideControlComponent = (
           onChange={onChange}
           onMouseDown={onMouseDown}
           onMouseUp={onMouseUp}
-          style={props.style}
         ></input>
       </div>
     </div>

--- a/src/ui/widgets/createComponent.tsx
+++ b/src/ui/widgets/createComponent.tsx
@@ -41,11 +41,6 @@ export function widgetDescriptionToComponent(
     border = undefined,
     minWidth = undefined,
     maxWidth = undefined,
-    color = undefined,
-    font = undefined,
-    fontSize = undefined,
-    fontWeight = undefined,
-    textAlign = undefined,
     ...otherProps
   } = constProps;
 
@@ -93,15 +88,6 @@ export function widgetDescriptionToComponent(
     maxWidth: maxWidth
   });
 
-  const widgetStyling = filterUndefinedOut({
-    color: color,
-    font: font,
-    fontSize: fontSize,
-    fontWeight: fontWeight,
-    textAlign: textAlign,
-    backgroundColor: backgroundColor
-  });
-
   // Perform checking on propTypes
   const widgetInfo = { containerStyling: containerStyling, ...otherProps };
   const error: string | undefined = checkPropTypes(
@@ -141,8 +127,8 @@ export function widgetDescriptionToComponent(
       // If this component has siblings, use its index in the array as a key.
       key={listIndex}
       containerStyling={containerStyling}
-      widgetStyling={widgetStyling}
       macroMap={latestMacroMap}
+      backgroundColor={backgroundColor}
       {...otherProps}
     >
       {ChildComponents}

--- a/src/ui/widgets/widget.tsx
+++ b/src/ui/widgets/widget.tsx
@@ -19,18 +19,13 @@ import {
   InferWidgetProps,
   StringProp,
   StringOrNumPropOpt,
-  ChoicePropOpt,
   MacrosProp,
   MacrosPropOpt
 } from "./propTypes";
 
 // Useful types for components which will later be turned into widgets
 // Required to define stateless component
-export interface Component {
-  style?: object;
-}
-
-export type PVComponent = Component & PvState;
+export type PVComponent = PvState;
 export type PVInputComponent = PVComponent & { pvName: string };
 
 const RulesPropType = PropTypes.shape({
@@ -58,18 +53,7 @@ const FlexibleContainerProps = {
   ...ContainerFeaturesPropType
 };
 
-const WidgetStylingPropType = {
-  font: StringPropOpt,
-  fontSize: StringOrNumPropOpt,
-  fontWeight: StringOrNumPropOpt,
-  textAlign: ChoicePropOpt(["center", "left", "right", "justify"]),
-  backgroundColor: StringPropOpt,
-  color: StringPropOpt
-};
-type WidgetStyling = InferWidgetProps<typeof WidgetStylingPropType>;
-
 const CommonWidgetProps = {
-  widgetStyling: PropTypes.shape(WidgetStylingPropType),
   macroMap: MacrosPropOpt,
   rules: PropTypes.arrayOf(RulesPropType),
   actions: ActionsPropType,
@@ -120,19 +104,13 @@ type PVWidgetComponent = PVWidgetProps & { baseWidget: React.FC<any> };
 const recursiveWrapping = (
   components: React.FC<any>[],
   containerStyling: object,
-  widgetStyling: WidgetStyling | null,
   containerProps: object,
   widgetProps: object
 ): JSX.Element => {
   const [Component, ...remainingComponents] = components;
   if (components.length === 1) {
     // Return the base widget
-    return (
-      <Component
-        style={{ ...containerStyling, ...widgetStyling }}
-        {...widgetProps}
-      />
-    );
+    return <Component style={{ ...containerStyling }} {...widgetProps} />;
   }
   // If container styling is not empty, use it on the wrapper widget
   // and pass on an empty object, otherwise wrap and move down
@@ -142,7 +120,6 @@ const recursiveWrapping = (
         {recursiveWrapping(
           remainingComponents,
           { height: "100%", width: "100%" },
-          widgetStyling,
           containerProps,
           widgetProps
         )}
@@ -154,7 +131,6 @@ const recursiveWrapping = (
 const WrappedComponents = (props: {
   components: React.FC<any>[];
   containerStyling: object;
-  widgetStyling: WidgetStyling | null;
   containerProps: any & { id: string };
   widgetProps: any;
 }): JSX.Element => {
@@ -168,7 +144,6 @@ const WrappedComponents = (props: {
   return recursiveWrapping(
     props.components,
     props.containerStyling,
-    props.widgetStyling,
     {
       ...props.containerProps,
       pvName: effectivePvName,
@@ -208,7 +183,7 @@ export const Widget = (props: WidgetComponent): JSX.Element => {
   const mappedContainerStyling = { top: y, left: x, ...containerStyling };
 
   // Extract remaining parameters
-  const { baseWidget, widgetStyling = {}, ...baseWidgetProps } = containerProps;
+  const { baseWidget, ...baseWidgetProps } = containerProps;
 
   // Put appropriate components on the list of components to be wrapped
   const components = [];
@@ -221,7 +196,6 @@ export const Widget = (props: WidgetComponent): JSX.Element => {
   return recursiveWrapping(
     components,
     mappedContainerStyling,
-    widgetStyling,
     containerProps,
     baseWidgetProps
   );
@@ -251,7 +225,6 @@ export const PVWidget = (props: PVWidgetComponent): JSX.Element => {
   // Extract remaining parameters
   const {
     baseWidget,
-    widgetStyling = {},
     alarmBorder = false,
     ...baseWidgetProps
   } = containerProps;
@@ -271,7 +244,6 @@ export const PVWidget = (props: PVWidgetComponent): JSX.Element => {
     <WrappedComponents
       components={components}
       containerStyling={mappedContainerStyling}
-      widgetStyling={widgetStyling}
       containerProps={containerProps}
       widgetProps={baseWidgetProps}
     />


### PR DESCRIPTION
All such props are now required at the top level of the widget itself.

@TimGuiteDiamond this is what this change would look like. I am tempted to merge this and move on. I might revert some of this later depending on how it pans out.