### PR TITLE
Performace measurement

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,11 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "serve -s build -l 3000",
+      "url": [
+        "http://localhost:3000/app/performance/{}/",
+        "http://localhost:3000/app/performanceDifferentPVs/{}/"
+      ]
+    }
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: node_js
 node_js:
   - 11
+
+addons:
+  chrome: stable # make Chrome available
+
+before_install:
+  - npm install -g @lhci/cli@0.3.x # install Lighthouse CI
+
 script:
   - npm test -- --coverage
   - npm run prettier-check
   - npm run coveralls
   - npm run lint
   - npx tsc
+  - CI=false npm run build
+
+after_success:
+  - lhci autorun --upload.target=temporary-public-storage # run lighthouse CI against your static site

--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,6 +2191,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "@zeit/schemas": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.6.0.tgz",
+      "integrity": "sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg=="
+    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -2311,6 +2316,43 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "requires": {
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -2555,6 +2597,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
+    },
+    "arg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
+      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -3414,6 +3466,54 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4450,6 +4550,11 @@
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4476,6 +4581,104 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.1.0.tgz",
       "integrity": "sha512-Xsu1NddBXB89IUauda5BIq3Zq73UWkjkaQlPQbLNvNsd5WBMnTWPNKYR6HGaySOxGYZ+BKxP2E9X4ElnI3yiPA=="
+    },
+    "clipboardy": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+      "requires": {
+        "arch": "^2.1.0",
+        "execa": "^0.8.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -5271,6 +5474,11 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -7206,6 +7414,21 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
     },
     "fastq": {
       "version": "1.6.0",
@@ -13683,6 +13906,11 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
@@ -13831,6 +14059,24 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -14905,6 +15151,23 @@
         "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
     "regjsgen": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
@@ -15636,6 +15899,117 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
       "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+    },
+    "serve": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-11.3.0.tgz",
+      "integrity": "sha512-AU0g50Q1y5EVFX56bl0YX5OtVjUX1N737/Htj93dQGKuHiuLvVB45PD8Muar70W6Kpdlz8aNJfoUqTyAq9EE/A==",
+      "requires": {
+        "@zeit/schemas": "2.6.0",
+        "ajv": "6.5.3",
+        "arg": "2.0.0",
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "clipboardy": "1.2.3",
+        "compression": "1.7.3",
+        "serve-handler": "6.1.2",
+        "update-check": "1.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "compression": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+          "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+          "requires": {
+            "accepts": "~1.3.5",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.14",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.1",
+            "safe-buffer": "5.1.2",
+            "vary": "~1.1.2"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "serve-handler": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.2.tgz",
+      "integrity": "sha512-RFh49wX7zJmmOVDcIjiDSJnMH+ItQEvyuYLYuDBVoA/xmQSCuj+uRmk1cmBB5QQlI3qOiWKp6p4DUGY+Z5AB2A==",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        }
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -16607,6 +16981,103 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "requires": {
+        "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "terser": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
@@ -17104,6 +17575,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+    },
+    "update-check": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
+      "integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
+      "requires": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -17883,6 +18363,43 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "requires": {
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-scripts": "^3.3.0",
     "react-tiny-popover": "^4.0.0",
     "redux": "^4.0.5",
+    "serve": "^11.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "typescript": "^3.7.5",
     "xml-js": "^1.6.11"

--- a/public/json/performanceDifferentPVs.json
+++ b/public/json/performanceDifferentPVs.json
@@ -1,0 +1,1215 @@
+{
+    "type": "display",
+    "containerStyling": {
+        "position": "absolute",
+        "x": "0px",
+        "y": "0px",
+        "width": "500px",
+        "height": "500px"
+    },
+    "widgetStyling": {
+        "backgroundColor": "#999999"
+    },
+    "children": [
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "2px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#00",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "2px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#01",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "2px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#02",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "2px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#03",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "2px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#04",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "24px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#05",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "24px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#06",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "24px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#07",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "24px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#08",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "24px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#09",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "46px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#10",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "46px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#11",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "46px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#12",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "46px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#13",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "46px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#14",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "68px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#15",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "68px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#16",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "68px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#17",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "68px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#18",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "68px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#19",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "90px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#20",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "90px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#21",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "90px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#22",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "90px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#23",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "90px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#24",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "112px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#25",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "112px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#26",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "112px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#27",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "112px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#28",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "112px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#29",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "134px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#30",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "134px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#31",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "134px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#32",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "134px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#33",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "134px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#34",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "156px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#35",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "156px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#36",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "156px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#37",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "156px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#38",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "156px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#39",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "178px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#40",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "178px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#41",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "178px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#42",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "178px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#43",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "178px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#44",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "200px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#45",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "200px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#46",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "200px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#47",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "200px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#48",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "200px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#49",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "222px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#50",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "222px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#51",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "222px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#52",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "222px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#53",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "222px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#54",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "244px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#55",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "244px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#56",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "244px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#57",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "244px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#58",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "244px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#59",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "266px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#60",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "266px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#61",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "266px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#62",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "266px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#63",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "266px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#64",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "288px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#65",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "288px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#66",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "288px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#67",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "288px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#68",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "288px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#69",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "310px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#70",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "310px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#71",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "310px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#72",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "310px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#73",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "310px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#74",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "332px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#75",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "332px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#76",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "332px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#77",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "332px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#78",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "332px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#79",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "354px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#80",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "354px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#81",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "354px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#82",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "354px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#83",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "354px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#84",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "376px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#85",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "376px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#86",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "376px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#87",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "376px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#88",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "376px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#89",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "398px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#90",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "398px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#91",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "398px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#92",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "398px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#93",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "398px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#94",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "2px",
+                "y": "420px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#95",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "84px",
+                "y": "420px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#96",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "166px",
+                "y": "420px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#97",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "248px",
+                "y": "420px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#98",
+            "precision": 0
+        },
+        {
+            "type": "readback",
+            "containerStyling": {
+                "position": "absolute",
+                "x": "330px",
+                "y": "420px",
+                "width": "80px",
+                "height": "20px"
+            },
+            "pvName": "sim://ramp#99",
+            "precision": 0
+        }
+    ]
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Profiler } from "react";
 import "./app.css";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
@@ -33,8 +33,28 @@ function applyTheme(theme: any): void {
   });
 }
 
+function onRenderCallback(
+  id: string,
+  phase: "mount" | "update",
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+  interactions: any
+) {
+  const reconciliationTime = commitTime - startTime;
+  console.table({
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+    reconciliationTime
+  });
+}
+
 const App: React.FC = (): JSX.Element => {
-  const simulator = new SimulatorPlugin(100);
+  const simulator = new SimulatorPlugin(5000);
   const fallbackPlugin = simulator;
   const plugins: [string, Connection][] = [
     ["sim://", simulator],
@@ -85,19 +105,21 @@ const App: React.FC = (): JSX.Element => {
                 ]
               }}
             />
-            <DynamicPageWidget
-              routePath="app"
-              containerStyling={{
-                position: "relative",
-                height: "",
-                width: "",
-                margin: "",
-                padding: "",
-                border: "",
-                minWidth: "",
-                maxWidth: ""
-              }}
-            />
+            <Profiler id="Dynamic Page Profiler" onRender={onRenderCallback}>
+              <DynamicPageWidget
+                routePath="app"
+                containerStyling={{
+                  position: "relative",
+                  height: "",
+                  width: "",
+                  margin: "",
+                  padding: "",
+                  border: "",
+                  minWidth: "",
+                  maxWidth: ""
+                }}
+              />
+            </Profiler>
           </div>
         </Provider>
       </BrowserRouter>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,7 @@ import { Connection } from "./connection/plugin";
 import { ActionButton } from "./ui/widgets";
 import { OPEN_PAGE } from "./ui/widgets/widgetActions";
 import { BaseUrlContext } from "./baseUrl";
+import { onRenderCallback } from "./profilerCallback";
 
 let settings: any;
 try {
@@ -23,6 +24,7 @@ try {
 }
 
 const baseUrl = settings.baseUrl ?? "http://localhost:3000";
+const SIMULATION_TIME = settings.simulationTime ?? 100;
 
 log.setLevel("info");
 
@@ -31,50 +33,6 @@ function applyTheme(theme: any): void {
     const value = theme[key];
     document.documentElement.style.setProperty(key, value);
   });
-}
-
-const SIMULATION_TIME = 1000;
-
-const recordedTimings = {
-  startTime: 0,
-  actualDur: 0,
-  baseDur: 0,
-  reconciliation: 0
-};
-
-function onRenderCallback(
-  id: string,
-  phase: "mount" | "update",
-  actualDuration: number,
-  baseDuration: number,
-  startTime: number,
-  commitTime: number,
-  interactions: any
-): void {
-  const reconciliationTime = commitTime - startTime;
-
-  if (
-    recordedTimings.startTime === 0 ||
-    startTime > recordedTimings.startTime + SIMULATION_TIME / 2
-  ) {
-    // Add final timings
-    recordedTimings.actualDur += actualDuration;
-    recordedTimings.baseDur += baseDuration;
-    recordedTimings.reconciliation += reconciliationTime;
-    // Produce a csv friendly output
-    log.info(`actualDuration,baseDuration,reconciliation
-  ${recordedTimings.actualDur},${recordedTimings.baseDur},${recordedTimings.reconciliation}`);
-    // Reset timings
-    recordedTimings.startTime = startTime;
-    recordedTimings.actualDur = 0;
-    recordedTimings.baseDur = 0;
-    recordedTimings.reconciliation = 0;
-  } else {
-    // Add timings
-    recordedTimings.actualDur += actualDuration;
-    recordedTimings.baseDur += baseDuration;
-    recordedTimings.reconciliation += reconciliationTime;
-  }
 }
 
 const App: React.FC = (): JSX.Element => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,7 +13,6 @@ import { Connection } from "./connection/plugin";
 import { ActionButton } from "./ui/widgets";
 import { OPEN_PAGE } from "./ui/widgets/widgetActions";
 import { BaseUrlContext } from "./baseUrl";
-import { start } from "repl";
 
 let settings: any;
 try {
@@ -36,7 +35,7 @@ function applyTheme(theme: any): void {
 
 const SIMULATION_TIME = 1000;
 
-const recorded_timings = {
+const recordedTimings = {
   startTime: 0,
   actualDur: 0,
   baseDur: 0,
@@ -51,30 +50,30 @@ function onRenderCallback(
   startTime: number,
   commitTime: number,
   interactions: any
-) {
+): void {
   const reconciliationTime = commitTime - startTime;
 
   if (
-    recorded_timings.startTime === 0 ||
-    startTime > recorded_timings.startTime + SIMULATION_TIME / 2
+    recordedTimings.startTime === 0 ||
+    startTime > recordedTimings.startTime + SIMULATION_TIME / 2
   ) {
     // Add final timings
-    recorded_timings.actualDur += actualDuration;
-    recorded_timings.baseDur += baseDuration;
-    recorded_timings.reconciliation += reconciliationTime;
+    recordedTimings.actualDur += actualDuration;
+    recordedTimings.baseDur += baseDuration;
+    recordedTimings.reconciliation += reconciliationTime;
     // Produce a csv friendly output
     log.info(`actualDuration,baseDuration,reconciliation
-  ${recorded_timings.actualDur},${recorded_timings.baseDur},${recorded_timings.reconciliation}`);
+  ${recordedTimings.actualDur},${recordedTimings.baseDur},${recordedTimings.reconciliation}`);
     // Reset timings
-    recorded_timings.startTime = startTime;
-    recorded_timings.actualDur = 0;
-    recorded_timings.baseDur = 0;
-    recorded_timings.reconciliation = 0;
+    recordedTimings.startTime = startTime;
+    recordedTimings.actualDur = 0;
+    recordedTimings.baseDur = 0;
+    recordedTimings.reconciliation = 0;
   } else {
     // Add timings
-    recorded_timings.actualDur += actualDuration;
-    recorded_timings.baseDur += baseDuration;
-    recorded_timings.reconciliation += reconciliationTime;
+    recordedTimings.actualDur += actualDuration;
+    recordedTimings.baseDur += baseDuration;
+    recordedTimings.reconciliation += reconciliationTime;
   }
 }
 

--- a/src/profilerCallback.ts
+++ b/src/profilerCallback.ts
@@ -1,0 +1,56 @@
+import log from "loglevel";
+
+let settings: any;
+try {
+  // Use require so that we can catch this error
+  settings = require("./settings");
+} catch (e) {
+  settings = {};
+}
+
+const PROFILE_ENABLED = settings.profilerEnabled ?? false;
+const SIMULATION_TIME = settings.simulationTime ?? 100;
+
+const recordedTimings = {
+  startTime: 0,
+  actualDur: 0,
+  baseDur: 0,
+  reconciliation: 0
+};
+
+export function onRenderCallback(
+  id: string,
+  phase: "mount" | "update",
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+  interactions: any
+): void {
+  if (PROFILE_ENABLED) {
+    const reconciliationTime = commitTime - startTime;
+
+    if (
+      recordedTimings.startTime === 0 ||
+      startTime > recordedTimings.startTime + SIMULATION_TIME / 2
+    ) {
+      // Add final timings
+      recordedTimings.actualDur += actualDuration;
+      recordedTimings.baseDur += baseDuration;
+      recordedTimings.reconciliation += reconciliationTime;
+      // Produce a csv friendly output
+      log.info(`actualDuration,baseDuration,reconciliation
+    ${recordedTimings.actualDur},${recordedTimings.baseDur},${recordedTimings.reconciliation}`);
+      // Reset timings
+      recordedTimings.startTime = startTime;
+      recordedTimings.actualDur = 0;
+      recordedTimings.baseDur = 0;
+      recordedTimings.reconciliation = 0;
+    } else {
+      // Add timings
+      recordedTimings.actualDur += actualDuration;
+      recordedTimings.baseDur += baseDuration;
+      recordedTimings.reconciliation += reconciliationTime;
+    }
+  }
+}

--- a/src/settings.ts.template
+++ b/src/settings.ts.template
@@ -1,3 +1,4 @@
-export const coniqlSocket = "localhost:1000";
-export const simulationTime = 100;
-export const profilerEnabled = true;
+export const coniqlSocket = "localhost:1000"; // Address of Coniql server
+export baseUrl = "http://localhost:3000" // Base URL to look at to get screen files
+export const simulationTime = 100; // Change the time between sim PV updates (ms)
+export const profilerEnabled = true; // Enable the profiler component

--- a/src/settings.ts.template
+++ b/src/settings.ts.template
@@ -1,1 +1,3 @@
 export const coniqlSocket = "localhost:1000";
+export const simulationTime = 100;
+export const profilerEnabled = true;


### PR DESCRIPTION
Use the React profiler component to produce highly useable information regarding render times for the main subtree.

Would be nice to wrap this up into its own file but at the moment it is dependent on the simulation time setting. I think this should perhaps be moved into `settings.ts` anyway as in the future other developers or sites might want to tweak this setting without having to edit and rebuild the code.

It would also be interesting to see how we can make this output more useful and generate it by running a test, either on our own machines or as part of the CI job.