### PR TITLE
groupingContainer and groupBox were both exporting functions called G…

### DIFF
--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -31,8 +31,8 @@ const GroupBoxProps = {
   children: ChildrenPropOpt
 };
 
-export const GroupingContainer = (
+export const GroupBox = (
   props: InferWidgetProps<typeof GroupBoxProps>
 ): JSX.Element => <Widget baseWidget={GroupBoxComponent} {...props} />;
 
-registerWidget(GroupingContainer, GroupBoxProps, "grouping");
+registerWidget(GroupBox, GroupBoxProps, "groupingBox");

--- a/src/ui/widgets/GroupBox/groupBox.tsx
+++ b/src/ui/widgets/GroupBox/groupBox.tsx
@@ -35,4 +35,4 @@ export const GroupBox = (
   props: InferWidgetProps<typeof GroupBoxProps>
 ): JSX.Element => <Widget baseWidget={GroupBoxComponent} {...props} />;
 
-registerWidget(GroupBox, GroupBoxProps, "groupingBox");
+registerWidget(GroupBox, GroupBoxProps, "groupBox");

--- a/src/ui/widgets/GroupingContainer/groupingContainer.tsx
+++ b/src/ui/widgets/GroupingContainer/groupingContainer.tsx
@@ -53,4 +53,4 @@ export const GroupingContainer = (
   props: InferWidgetProps<typeof GroupingWidgetProps>
 ): JSX.Element => <Widget baseWidget={GroupingContainerComponent} {...props} />;
 
-registerWidget(GroupingContainer, GroupingWidgetProps, "grouping");
+registerWidget(GroupingContainer, GroupingWidgetProps, "groupingContainer");

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -3,6 +3,7 @@ export { Display } from "./Display/display";
 export { DynamicPageWidget } from "./DynamicPage/dynamicPage";
 export { EmbeddedDisplay } from "./EmbeddedDisplay/embeddedDisplay";
 export { FlexContainer } from "./FlexContainer/flexContainer";
+export { GroupBox } from "./GroupBox/groupBox";
 export { GroupingContainer } from "./GroupingContainer/groupingContainer";
 export { Image } from "./Image/image";
 export { Input } from "./Input/input";


### PR DESCRIPTION
 groupingContainer and groupBox were both exporting functions called GroupingContainer, they were both registering with the same name as well. The names both widgets register with and the name of the exported functions have been changed.

