### PR TITLE
Making sizes in web more similar to sizes in CS-Studio, by subtractin…

### DIFF
--- a/src/ui/widgets/LED/led.module.css
+++ b/src/ui/widgets/LED/led.module.css
@@ -1,6 +1,6 @@
 .Led {
-  width: 16px;
-  height: 16px;
+  width: 11px;
+  height: 11px;
   border-radius: 50%;
   background-color: #00ee00;
 }

--- a/src/ui/widgets/LED/led.test.tsx
+++ b/src/ui/widgets/LED/led.test.tsx
@@ -71,7 +71,10 @@ describe("width property is used", (): void => {
   test("width changes the size of the LED", (): void => {
     const renderedLed = renderLed({ width: 10 });
 
-    expect(renderedLed.props.style.width).toBe("10px");
-    expect(renderedLed.props.style.height).toBe("10px");
+    // Width in CS-Studio doesn't quite match width in the browser,
+    // so whatever is input has 5 subtracted from it, this makes it
+    // look more like CS-Studio
+    expect(renderedLed.props.style.width).toBe("5px");
+    expect(renderedLed.props.style.height).toBe("5px");
   });
 });

--- a/src/ui/widgets/LED/led.tsx
+++ b/src/ui/widgets/LED/led.tsx
@@ -39,8 +39,10 @@ export const LedComponent = (props: LedComponentProps): JSX.Element => {
   const style: any = {};
 
   if (width) {
-    style.width = `${width}px`;
-    style.height = `${width}px`;
+    // make sizes similar to size in CS-Studio, five taken
+    // away from default in css file too
+    style.width = `${width - 5}px`;
+    style.height = `${width - 5}px`;
   }
 
   let allClasses = classes.Led;


### PR DESCRIPTION
Minor update, to make the LED in the web look more similar to the size in CS-Studio, a fixed value of 5 pixels is subtracted from the value received from the .opi file. Tests have then been updated.