### PR TITLE
Coniql.ts build failure

### DIFF
--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -262,8 +262,10 @@ export class ConiqlPlugin implements Connection {
       log.error("Websockect client disconnected.");
       for (const pvName of Object.keys(this.subscriptions)) {
         if (this.subscriptions.hasOwnProperty(pvName)) {
-          this.subscriptions[pvName].unsubscribe();
-          delete this.subscriptions[pvName];
+          if (this.subscriptions[pvName]) {
+            this.subscriptions[pvName].unsubscribe();
+            delete this.subscriptions[pvName];
+          }
         } else {
           log.error(`Attempt to unsubscribe from ${pvName} failed`);
         }

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -261,11 +261,12 @@ export class ConiqlPlugin implements Connection {
     this.wsClient.onDisconnected((): void => {
       log.error("Websockect client disconnected.");
       for (const pvName of Object.keys(this.subscriptions)) {
-        if (this.subscriptions.hasOwnProperty(pvName)) {
-          if (this.subscriptions[pvName]) {
-            this.subscriptions[pvName].unsubscribe();
-            delete this.subscriptions[pvName];
-          }
+        if (
+          this.subscriptions.hasOwnProperty(pvName) &&
+          this.subscriptions[pvName]
+        ) {
+          this.subscriptions[pvName].unsubscribe();
+          delete this.subscriptions[pvName];
         } else {
           log.error(`Attempt to unsubscribe from ${pvName} failed`);
         }

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -261,8 +261,12 @@ export class ConiqlPlugin implements Connection {
     this.wsClient.onDisconnected((): void => {
       log.error("Websockect client disconnected.");
       for (const pvName of Object.keys(this.subscriptions)) {
-        this.subscriptions[pvName].unsubscribe();
-        delete this.subscriptions[pvName];
+        if (this.subscriptions.hasOwnProperty(pvName)) {
+          this.subscriptions[pvName].unsubscribe();
+          delete this.subscriptions[pvName];
+        } else {
+          log.error(`Attempt to unsubscribe from ${pvName} failed`);
+        }
         this.onConnectionUpdate(pvName, {
           isConnected: false,
           isReadonly: true


### PR DESCRIPTION
Commonly Travis is failing to build a PR due to an error in coniql.ts where the code attempts to access the `.unsubscribe()` method on an undefined object (this error can be seen on the image+symbol open PR). I believe @willrogers attempted a fix but there still seems to be problems. This isn't meant to be permanent just a way to fix the build until we have a better solution.