### PR TITLE
Device parsing

### DIFF
--- a/public/json/devicePage.json
+++ b/public/json/devicePage.json
@@ -7,7 +7,7 @@
   "children": [
     {
       "type": "device",
-      "deviceName": "dev://M1Yaw",
+      "deviceName": "M1Yaw",
       "position": "relative",
       "width": "100%"
     }

--- a/public/opi/device.opi
+++ b/public/opi/device.opi
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color name="Canvas" red="200" green="200" blue="200" />
+  </background_color>
+  <boy_version>5.1.0.201612131649</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>5</grid_space>
+  <height>800</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name>$(name)</name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>600</width>
+  <wuid>-4f4b678c:14c085f666c:-75a0</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.detailpanel" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <color_even_row_back>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </color_even_row_back>
+    <color_even_row_fore>
+      <color red="0" green="0" blue="0" />
+    </color_even_row_fore>
+    <color_odd_row_back>
+      <color name="Controller: BG" red="205" green="205" blue="205" />
+    </color_odd_row_back>
+    <color_odd_row_fore>
+      <color red="0" green="0" blue="0" />
+    </color_odd_row_fore>
+    <color_select_back>
+      <color red="217" green="217" blue="255" />
+    </color_select_back>
+    <color_select_fore>
+      <color red="0" green="0" blue="0" />
+    </color_select_fore>
+    <display_level>0</display_level>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="11" style="0">Default</opifont.name>
+    </font>
+    <height>1000</height>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <device_name>$(DESC)</device_name>
+    <name>Detail Panel</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip></tooltip>
+    <vert_divider_pos>160</vert_divider_pos>
+    <visible>true</visible>
+    <widget_type>Detail Panel</widget_type>
+    <width>400</width>
+    <wuid>-4f4b678c:14c085f666c:-759f</wuid>
+    <x>0</x>
+    <y>0</y>
+  </widget>
+</display>

--- a/public/opi/motor_embed.opi
+++ b/public/opi/motor_embed.opi
@@ -143,7 +143,7 @@ $(pv_value)</tooltip>
   <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
     <actions hook="false" hook_all="true">
       <action type="OPEN_DISPLAY">
-        <path>motor_detail.opi</path>
+        <path>device.opi</path>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>

--- a/src/connection/fragmentTypes.json
+++ b/src/connection/fragmentTypes.json
@@ -1,1 +1,17 @@
-{"__schema":{"types":[{"kind":"INTERFACE","name":"Meta","possibleTypes":[{"name":"FunctionMeta"},{"name":"ObjectMeta"},{"name":"EnumMeta"},{"name":"NumberMeta"},{"name":"TableMeta"}]}]}}
+{
+  "__schema": {
+    "types": [
+      {
+        "kind": "INTERFACE",
+        "name": "Meta",
+        "possibleTypes": [
+          { "name": "FunctionMeta" },
+          { "name": "ObjectMeta" },
+          { "name": "EnumMeta" },
+          { "name": "NumberMeta" },
+          { "name": "TableMeta" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/redux/connectionMiddleware.ts
+++ b/src/redux/connectionMiddleware.ts
@@ -120,9 +120,14 @@ export const connectionMiddleware = (connection: Connection) => (
     }
     case QUERY_DEVICE: {
       const { device } = action.payload;
-      // Devices should be queried once and then stored
-      if (!store.getState().deviceCache[device]) {
-        connection.getDevice(device);
+      try {
+        // Devices should be queried once and then stored
+        if (!store.getState().deviceCache[device]) {
+          connection.getDevice(device);
+        }
+      } catch (error) {
+        log.error(`Failed to query device ${device}`);
+        log.error(error);
       }
       break;
     }

--- a/src/redux/throttleMiddleware.test.ts
+++ b/src/redux/throttleMiddleware.test.ts
@@ -53,7 +53,6 @@ describe("throttleMidddlware", (): void => {
   });
   it("dispatches ValuesChanged when receiving ValueChanged", (): void => {
     const middleware = throttleMiddleware(updater);
-    updater.ready = true;
     // nextHandler takes next() and returns the actual middleware function
     const nextHandler = middleware(mockStore);
     const mockNext = jest.fn();
@@ -64,10 +63,9 @@ describe("throttleMidddlware", (): void => {
       payload: { pvName: "pv", value: ddouble(0) }
     };
     actionHandler(valueAction);
-    expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(0);
     // The value update is not passed on.
     expect(mockNext).not.toHaveBeenCalled();
-    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual(VALUES_CHANGED);
   });
 
   it("doesn't dispatch when receiving ConnectionChanged", (): void => {

--- a/src/redux/throttleMiddleware.test.ts
+++ b/src/redux/throttleMiddleware.test.ts
@@ -63,7 +63,11 @@ describe("throttleMidddlware", (): void => {
       payload: { pvName: "pv", value: ddouble(0) }
     };
     actionHandler(valueAction);
-    expect(mockStore.dispatch).toHaveBeenCalledTimes(0);
+
+    // manually trigger the dispatch
+    updater.sendQueue(mockStore);
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(1);
+    expect(mockStore.dispatch.mock.calls[0][0].type).toEqual(VALUES_CHANGED);
     // The value update is not passed on.
     expect(mockNext).not.toHaveBeenCalled();
   });

--- a/src/redux/throttleMiddleware.ts
+++ b/src/redux/throttleMiddleware.ts
@@ -3,18 +3,21 @@ import { MiddlewareAPI, Dispatch } from "redux";
 
 export class UpdateThrottle {
   private queue: Action[];
-  public ready: boolean;
+  private started: boolean;
+  private updateMillis: number;
+
   constructor(updateMillis: number) {
     this.queue = [];
-    this.ready = false;
-    setInterval(() => (this.ready = true), updateMillis);
+    this.started = false;
+    this.updateMillis = updateMillis;
   }
 
   public queueUpdate(action: Action, store: MiddlewareAPI): void {
-    this.queue.push(action);
-    if (this.ready) {
-      this.sendQueue(store);
+    if (!this.started) {
+      setInterval(() => this.sendQueue(store), this.updateMillis);
+      this.started = true;
     }
+    this.queue.push(action);
   }
 
   public sendQueue(store: MiddlewareAPI): void {
@@ -22,7 +25,6 @@ export class UpdateThrottle {
       store.dispatch({ type: VALUES_CHANGED, payload: [...this.queue] });
       this.queue = [];
     }
-    this.ready = false;
   }
 }
 

--- a/src/ui/hooks/utils.test.ts
+++ b/src/ui/hooks/utils.test.ts
@@ -79,9 +79,15 @@ describe("pvStateComparator", (): void => {
 });
 
 describe("deviceComparator", (): void => {
-  it("returns false always", (): void => {
+  it("returns false if string values don't match", (): void => {
+    const dtype1 = new DType({ stringValue: "42" });
+    const dtype2 = new DType({ stringValue: "43" });
+    expect(deviceComparator(dtype1, dtype2)).toBe(false);
+  });
+
+  it("returns true if string values do match", (): void => {
     const dtype = new DType({ stringValue: "42" });
-    expect(deviceComparator(dtype, dtype)).toBe(false);
+    expect(deviceComparator(dtype, dtype)).toBe(true);
   });
 });
 

--- a/src/ui/hooks/utils.ts
+++ b/src/ui/hooks/utils.ts
@@ -22,9 +22,13 @@ export function deviceSelector(device: string, state: CsState): DType {
 }
 
 export function deviceComparator(before: DType, after: DType): boolean {
-  // Note: comparing objects properly is difficult, given device queries
-  // are very infrequent can just always update
-  return false;
+  if (Object.keys(before).length !== Object.keys(after).length) {
+    return false;
+  }
+  if (before.value.stringValue !== after.value.stringValue) {
+    return false;
+  }
+  return true;
 }
 
 /* Used for preventing re-rendering if the results are equivalent.

--- a/src/ui/widgets/Device/device.test.tsx
+++ b/src/ui/widgets/Device/device.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { DeviceComponent } from "./device";
+import { render } from "@testing-library/react";
+import * as deviceHook from "../../hooks/useDevice";
+import * as jsonParsing from "../createComponent";
+import { DType } from "../../../types/dtypes";
+
+const useDeviceMock = jest
+  .spyOn(deviceHook, "useDevice")
+  .mockImplementation((device: string): DType | undefined => undefined);
+
+const descriptionToComponentMock = jest
+  .spyOn(jsonParsing, "widgetDescriptionToComponent")
+  .mockImplementation(() => <p>{"Mocked"}</p>);
+
+describe("<DeviceComponent />", (): void => {
+  test("adds dev:// to deviceName", (): void => {
+    render(<DeviceComponent deviceName={"fake Device"} />);
+    expect(useDeviceMock).toHaveBeenCalledWith("dev://fakeDevice");
+    expect(descriptionToComponentMock).toHaveBeenCalled();
+  });
+});

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -5,7 +5,7 @@ import { InferWidgetProps, StringProp } from "./../propTypes";
 import { registerWidget } from "./../register";
 import { useDevice } from "../../hooks/useDevice";
 import { parseResponse } from "./deviceParser";
-import { parseJson } from "../EmbeddedDisplay/jsonParser";
+import { parseObject } from "../EmbeddedDisplay/jsonParser";
 import { widgetDescriptionToComponent } from "../createComponent";
 import { RelativePosition } from "../../../types/position";
 import { BorderStyle, Border } from "../../../types/border";
@@ -27,9 +27,9 @@ export const DeviceComponent = (
     jsonResponse = JSON.parse(description?.value?.stringValue || "");
     border = Border.NONE;
   }
-  const jsonString = parseResponse(jsonResponse as any);
+  const jsonObject = parseResponse(jsonResponse as any);
 
-  const componentDescription = parseJson(jsonString, "pva");
+  const componentDescription = parseObject(jsonObject, "pva");
 
   const Component = widgetDescriptionToComponent({
     position: new RelativePosition("100%", "100%"),

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Widget } from "./../widget";
+import { Widget, commonCss } from "./../widget";
 import { WidgetPropType } from "./../widgetProps";
 import { InferWidgetProps, StringProp } from "./../propTypes";
 import { registerWidget } from "./../register";
@@ -8,6 +8,8 @@ import { parseResponse } from "./deviceParser";
 import { parseJson } from "../EmbeddedDisplay/jsonParser";
 import { widgetDescriptionToComponent } from "../createComponent";
 import { RelativePosition } from "../../../types/position";
+import { BorderStyle, Border } from "../../../types/border";
+import { Color } from "../../../types/color";
 
 const DeviceProps = {
   deviceName: StringProp
@@ -19,9 +21,11 @@ export const DeviceComponent = (
   // Remove spaces from input
   const description = useDevice("dev://" + props.deviceName.replace(/\s/g, ""));
 
+  let border = new Border(BorderStyle.Dotted, Color.DISCONNECTED, 3);
   let jsonResponse = {};
   if (description && description.value) {
     jsonResponse = JSON.parse(description?.value?.stringValue || "");
+    border = Border.NONE;
   }
   const jsonString = parseResponse(jsonResponse as any);
 
@@ -33,7 +37,8 @@ export const DeviceComponent = (
     children: [componentDescription]
   });
 
-  return Component;
+  const style = commonCss({ border });
+  return <div style={style}>{Component}</div>;
 };
 
 const DeviceWidgetProps = {

--- a/src/ui/widgets/Device/device.tsx
+++ b/src/ui/widgets/Device/device.tsx
@@ -1,36 +1,39 @@
 import React from "react";
 import { Widget } from "./../widget";
 import { WidgetPropType } from "./../widgetProps";
-import { InferWidgetProps, StringPropOpt, StringProp } from "./../propTypes";
+import { InferWidgetProps, StringProp } from "./../propTypes";
 import { registerWidget } from "./../register";
 import { useDevice } from "../../hooks/useDevice";
-// import { parseJson } from "../EmbeddedDisplay/jsonParser";
-// import { widgetDescriptionToComponent } from "../createComponent";
-// import { RelativePosition } from "../../../types/position";
-// import { GroupBoxComponent } from "../GroupBox/groupBox";
+import { parseResponse } from "./deviceParser";
+import { parseJson } from "../EmbeddedDisplay/jsonParser";
+import { widgetDescriptionToComponent } from "../createComponent";
+import { RelativePosition } from "../../../types/position";
 
 const DeviceProps = {
-  deviceName: StringProp,
-  id: StringPropOpt
+  deviceName: StringProp
 };
 
-const DeviceComponent = (
+export const DeviceComponent = (
   props: InferWidgetProps<typeof DeviceProps>
 ): JSX.Element => {
-  const description = useDevice(props.deviceName);
-  // const jsonString = deviceParser(description?.value?.toString());
-  //
-  // const componentDescription = parseJson(jsonString, "pva");
-  //
-  // const component = widgetDescriptionToComponent({
-  // position: new RelativePosition("100%", "100%"),
-  // type: "display",
-  // children: [componentDescription]
-  // });
-  // return (
-  // <GroupBoxComponent name={props.deviceName}>{component}</GroupBoxComponent>
-  // );
-  return <p>{description?.value?.stringValue || "Device"}</p>;
+  // Remove spaces from input
+  const description = useDevice("dev://" + props.deviceName.replace(/\s/g, ""));
+
+  let jsonResponse = {};
+  if (description && description.value) {
+    jsonResponse = JSON.parse(description?.value?.stringValue || "");
+  }
+  const jsonString = parseResponse(jsonResponse as any);
+
+  const componentDescription = parseJson(jsonString, "pva");
+
+  const Component = widgetDescriptionToComponent({
+    position: new RelativePosition("100%", "100%"),
+    type: "display",
+    children: [componentDescription]
+  });
+
+  return Component;
 };
 
 const DeviceWidgetProps = {

--- a/src/ui/widgets/Device/deviceParser.test.ts
+++ b/src/ui/widgets/Device/deviceParser.test.ts
@@ -1,0 +1,138 @@
+import {
+  wordSplitter,
+  createLabel,
+  createReadback,
+  parseResponseIntoObject,
+  parseResponse,
+  Response
+} from "./deviceParser";
+
+describe("wordSplitter", (): void => {
+  test("Splits a word and trims spaces", (): void => {
+    const before = "WordSplitter";
+    const after = "Word Splitter";
+    expect(wordSplitter(before)).toEqual(after);
+  });
+
+  test("Splits multiple words", (): void => {
+    const before = "HereAreSomeWords";
+    const after = "Here Are Some Words";
+    expect(wordSplitter(before)).toEqual(after);
+  });
+});
+
+describe("createLabel", (): void => {
+  test("Empty label fills in with placeholder", (): void => {
+    expect(createLabel()).toMatch(`"text":"-"`);
+  });
+
+  test("Value is placed into label", (): void => {
+    expect(createLabel("ValueHere")).toMatch("Value Here");
+  });
+});
+
+describe("createReadback", (): void => {
+  test("Empty pv fills in with placeholder", (): void => {
+    expect(createReadback()).toMatch(`"pvName": ""`);
+  });
+
+  test("pv is placed into readback", (): void => {
+    expect(createReadback("PvName")).toMatch(`"pvName": "PvName"`);
+  });
+});
+
+const fakeResponseJson: Response = {
+  getDevice: {
+    id: "M1Yaw",
+    children: [
+      {
+        name: "Readback",
+        label: "Readback",
+        child: {
+          __typename: "Channel",
+          id: "ca://BL21I-OP-MIRR-01:YAW.RBV"
+        },
+        __typename: "NamedChild"
+      },
+      {
+        name: "Limits",
+        label: "Limits",
+        child: {
+          __typename: "Group",
+          layout: "BOX",
+          children: [{ name: "LimitViolation", __typename: "NamedChild" }]
+        },
+        __typename: "NamedChild"
+      },
+      {
+        name: "LimitViolation",
+        label: "Limit Violation",
+        child: {
+          __typename: "Channel",
+          id: "ca://BL21I-OP-MIRR-01:YAW.LVIO"
+        },
+        __typename: "NamedChild"
+      },
+      {
+        name: "Direction",
+        label: "Direction",
+        child: {
+          __typename: "Channel",
+          id: "ca://BL21I-OP-MIRR-01:YAW.DIR"
+        },
+        __typename: "NamedChild"
+      }
+    ],
+    __typename: "Device"
+  }
+};
+describe("parseResponseIntoObject", (): void => {
+  test("properties are extracted", (): void => {
+    const [deviceName, pvIds, groups] = parseResponseIntoObject(
+      fakeResponseJson
+    );
+    expect(deviceName).toEqual("M1Yaw");
+    expect(groups).toEqual({
+      Limits: ["LimitViolation"]
+    });
+    expect(pvIds).toEqual({
+      Readback: "ca://BL21I-OP-MIRR-01:YAW.RBV",
+      LimitViolation: "ca://BL21I-OP-MIRR-01:YAW.LVIO",
+      Direction: "ca://BL21I-OP-MIRR-01:YAW.DIR"
+    });
+  });
+
+  test("empty response returns empty objects", (): void => {
+    const [deviceName, pvIds, groups] = parseResponseIntoObject({} as Response);
+    expect(deviceName).toEqual("");
+    expect(pvIds).toEqual({});
+    expect(groups).toEqual({});
+  });
+});
+
+describe("parseResponse", (): void => {
+  test("empty response gives empty groupbox", (): void => {
+    const component = parseResponse({} as Response);
+    expect(component).toMatch(`"type": "groupbox"`);
+    expect(component).toMatch(`"name": "Device"`);
+    expect(component).toMatch(`"children": []`);
+  });
+
+  test("response is parsed", (): void => {
+    const component = parseResponse(fakeResponseJson);
+    expect(component).toMatch(`"name": "M1 Yaw"`);
+
+    // Check labels corresponding to PVs are present
+    expect(component).toMatch("Direction");
+    expect(component).toMatch("Limit Violation");
+    expect(component).toMatch("Readback");
+
+    // Check group label is present
+    expect(component).toMatch("Limits");
+
+    // Check PV names are present
+    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.RBV");
+    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.LVIO");
+    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.DIR");
+  });
+});

--- a/src/ui/widgets/Device/deviceParser.test.ts
+++ b/src/ui/widgets/Device/deviceParser.test.ts
@@ -23,21 +23,21 @@ describe("wordSplitter", (): void => {
 
 describe("createLabel", (): void => {
   test("Empty label fills in with placeholder", (): void => {
-    expect(createLabel()).toMatch(`"text":"-"`);
+    expect(createLabel().text).toBe("-");
   });
 
   test("Value is placed into label", (): void => {
-    expect(createLabel("ValueHere")).toMatch("Value Here");
+    expect(createLabel("ValueHere").text).toBe("Value Here");
   });
 });
 
 describe("createReadback", (): void => {
   test("Empty pv fills in with placeholder", (): void => {
-    expect(createReadback()).toMatch(`"pvName": ""`);
+    expect(createReadback().pvName).toBe("");
   });
 
   test("pv is placed into readback", (): void => {
-    expect(createReadback("PvName")).toMatch(`"pvName": "PvName"`);
+    expect(createReadback("PvName").pvName).toBe("PvName");
   });
 });
 
@@ -113,26 +113,26 @@ describe("parseResponseIntoObject", (): void => {
 describe("parseResponse", (): void => {
   test("empty response gives empty groupbox", (): void => {
     const component = parseResponse({} as Response);
-    expect(component).toMatch(`"type": "groupbox"`);
-    expect(component).toMatch(`"name": "Device"`);
-    expect(component).toMatch(`"children": []`);
+    expect(component.type).toBe("groupbox");
+    expect(component.name).toBe("Device");
+    expect(component.children[0].children.length).toBe(0);
   });
 
   test("response is parsed", (): void => {
     const component = parseResponse(fakeResponseJson);
-    expect(component).toMatch(`"name": "M1 Yaw"`);
+    expect(component.name).toMatch("M1 Yaw");
 
-    // Check labels corresponding to PVs are present
-    expect(component).toMatch("Direction");
-    expect(component).toMatch("Limit Violation");
-    expect(component).toMatch("Readback");
+    const children = component.children[0].children;
 
-    // Check group label is present
-    expect(component).toMatch("Limits");
+    // Individual pvs are first
+    expect(children[0].text).toBe("Readback");
+    expect(children[1].pvName).toBe("ca://BL21I-OP-MIRR-01:YAW.RBV");
+    expect(children[2].text).toBe("Direction");
+    expect(children[3].pvName).toBe("ca://BL21I-OP-MIRR-01:YAW.DIR");
 
-    // Check PV names are present
-    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.RBV");
-    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.LVIO");
-    expect(component).toMatch("ca://BL21I-OP-MIRR-01:YAW.DIR");
+    // Groups are next
+    const subChild = children[4].children[0].children;
+    expect(subChild[0].text).toBe("Limit Violation");
+    expect(subChild[1].pvName).toBe("ca://BL21I-OP-MIRR-01:YAW.LVIO");
   });
 });

--- a/src/ui/widgets/Device/deviceParser.ts
+++ b/src/ui/widgets/Device/deviceParser.ts
@@ -1,0 +1,153 @@
+import log from "loglevel";
+
+type Typename = "NamedChild" | "Channel" | "Group" | "Device";
+
+export interface Channel {
+  id: string;
+  __typename: Typename;
+}
+
+export interface Device {
+  id: string;
+  __typename: Typename;
+}
+
+export interface GroupChild {
+  name: string;
+  __typename: Typename;
+}
+
+export interface Group {
+  layout: string;
+  children: GroupChild[];
+  __typename: Typename;
+}
+
+type Child = Channel | Device | Group;
+
+export interface NamedChild {
+  name: string;
+  label: string;
+  child: Child;
+  __typename: Typename;
+}
+
+export interface Response {
+  getDevice: {
+    id: string;
+    children: NamedChild[];
+    __typename: Typename;
+  };
+}
+
+// Add spaces between capital letters e.g. WordSplitter -> Word Splitter
+export const wordSplitter = (word: string): string =>
+  word.replace(/([A-Z])/g, " $1").trim();
+
+export const createLabel = (value = "-"): string => {
+  let label = '{"type": "label", "position": "relative", "text":"';
+  // Put spaces between each capital letter
+  label += wordSplitter(value);
+  label += `", "width": "45%", "backgroundColor": "transparent", "margin": "5px 0 0 0"},`;
+  return label;
+};
+
+export const createReadback = (pv = ""): string => {
+  let readback =
+    '{"type": "readback", "position": "relative", "width": "45%", "margin": "5px 0 0 0", ';
+  readback += `"pvName": "${pv}"},`;
+  return readback;
+};
+
+export interface Groups {
+  [key: string]: Array<string>;
+}
+
+export interface Pvs {
+  [key: string]: string;
+}
+
+/**
+ * Takes response json and collects all the PVs in it, collects the groups and collects the names
+ * of the PVs that should be in that group
+ * @param response
+ */
+export const parseResponseIntoObject = (response: Response): any => {
+  const pvIds: Pvs = {};
+  const groups: Groups = {};
+  let deviceName = "";
+  if (response.getDevice) {
+    const { children, id } = response.getDevice;
+    deviceName = id;
+
+    for (const namedChild of children) {
+      if (namedChild.child.__typename === "Group") {
+        groups[namedChild.label] = (namedChild.child as Group).children.map(
+          groupChild => groupChild.name
+        );
+      } else if (namedChild.child.__typename === "Channel") {
+        pvIds[namedChild.name] = (namedChild.child as Channel).id;
+      } else {
+        log.error("Typename not handled");
+      }
+    }
+  }
+  return [deviceName, pvIds, groups];
+};
+
+export const parseResponse = (response: Response): string => {
+  let childrenComponents = '"children": [';
+
+  let deviceName = "Device";
+  if (response.getDevice) {
+    const [name, pvIds, groups]: [
+      string,
+      Pvs,
+      Groups
+    ] = parseResponseIntoObject(response);
+    deviceName = name;
+
+    // Parse groups into json string
+    const groupStrings = Object.entries(groups).map(data => {
+      const [groupName, pvNames] = data;
+
+      let child = `{"type": "groupbox", "width": "95%", "name": "${wordSplitter(
+        groupName
+      )}", "position": "relative", "margin": "10px 0 10px 0", "children": [{"type": "flexcontainer", "position": "relative", "overflow": "auto", "children": [`;
+      // For each pv in group find the PV id and display it with a readback and label
+      for (const pvName of pvNames) {
+        const id = pvIds[pvName];
+        delete pvIds[pvName];
+        child += createLabel(pvName);
+        child += createReadback(id);
+      }
+
+      // Chop off trailing comma
+      child = child.substring(0, child.length - 1);
+      child += "]}]},";
+      return child;
+    });
+
+    // PVs that aren't in a group are displayed first
+    Object.entries(pvIds).forEach(data => {
+      const [pvName, id] = data;
+      childrenComponents += createLabel(pvName);
+      childrenComponents += createReadback(id);
+    });
+
+    // Then groups are displayed after
+    groupStrings.forEach(child => (childrenComponents += child));
+
+    // Chop off trailing comma
+    childrenComponents = childrenComponents.substring(
+      0,
+      childrenComponents.length - 1
+    );
+  }
+
+  childrenComponents += "]";
+
+  return `{"type": "groupbox", "name": "${wordSplitter(
+    deviceName
+  )}", "position": "relative", "margin": "5px 0 0 0", "children": [{"type": "flexcontainer", "position": "relative", "overflow": "auto", ${childrenComponents} }]}`;
+};

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -56,7 +56,8 @@ const OPI_WIDGET_MAPPING: { [key: string]: any } = {
   "org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget":
     "symbol",
   "org.csstudio.opibuilder.widgets.progressbar": "progressbar",
-  "org.csstudio.opibuilder.widgets.LED": "led"
+  "org.csstudio.opibuilder.widgets.LED": "led",
+  "org.csstudio.opibuilder.widgets.detailpanel": "device"
 };
 
 /**
@@ -462,7 +463,8 @@ export const OPI_SIMPLE_PARSERS: ParserDict = {
   rotationAngle: ["rotation_angle", opiParseNumber],
   rotation: ["degree", opiParseNumber],
   flipHorizontal: ["flip_horizontal", opiParseBoolean],
-  flipVertical: ["flip_vertical", opiParseBoolean]
+  flipVertical: ["flip_vertical", opiParseBoolean],
+  deviceName: ["device_name", opiParseString]
 };
 
 /**


### PR DESCRIPTION
- Parsing to turn coniql device response into components
- throttleMiddleware bug was causing the queue not to flush, fixed this
- Tweaks to some of the infrastructure (hooks, comparator/selector)
- Modified motor_embed.opi to load new device.opi instead of old motor_detail.opi, device.opi uses parent macros to define the device to query from coniql
- detailPanel gets mapped to device